### PR TITLE
Explicitly add detection pass cmd args

### DIFF
--- a/varats/experiments/CommitAnnotationReport.py
+++ b/varats/experiments/CommitAnnotationReport.py
@@ -143,7 +143,7 @@ class CommitAnnotationReport(Experiment):
                 CFG["vara"]["outfile"].value) + "/" + str(
                     project.name) + "-" + str(project.run_uuid) + ".yaml"
             run_cmd = opt[
-                "-vara-CFR", outfile, project_src / project.name + ".bc"]
+                "-vara-CD", "-vara-CFR", outfile, project_src / project.name + ".bc"]
             run_cmd()
 
         analysis_actions = []

--- a/varats/experiments/GitBlameAnnotationReport.py
+++ b/varats/experiments/GitBlameAnnotationReport.py
@@ -95,7 +95,7 @@ class GitBlameAnntotationReport(Experiment):
                 str(CFG["vara"]["outfile"])) + "/" +\
                 str(project.name) + "-" + str(project.run_uuid) + ".yaml"
             run_cmd = opt[
-                "-vara-CFR", outfile, project_src / project.name + ".bc"]
+                "-vara-BD", "-vara-CFR", outfile, project_src / project.name + ".bc"]
             run_cmd()
 
         analysis_actions = []


### PR DESCRIPTION
Required because the detection passes are not implicitly called any
more.