### PR TITLE
Added Basic tests and tracer tester

### DIFF
--- a/varats/experiments/marker_tester.py
+++ b/varats/experiments/marker_tester.py
@@ -48,8 +48,9 @@ class TraceBinaryCreator(base.Extension):
 
         fake_file_name = src_file.replace(".cpp", "_fake.ll")
 
-        clang_stage_1 = command["-stdlib=libc++", "-fvara-handleRM=High", "-S",
-                                "-emit-llvm", "-o", fake_file_name, src_file]
+        clang_stage_1 = command[self.extra_ldflags, "-Qunused-arguments",
+                                "-fvara-handleRM=High", "-S", "-emit-llvm",
+                                "-o", fake_file_name, src_file]
         with run.track_execution(clang_stage_1, self.project,
                                  self.experiment) as _run:
             res.append(_run())

--- a/varats/experiments/marker_tester.py
+++ b/varats/experiments/marker_tester.py
@@ -1,0 +1,115 @@
+"""
+Instrument the generated binary with print markers to show region entry/exits.
+"""
+
+from plumbum import local
+
+from benchbuild.experiment import Experiment
+from benchbuild.extensions import base
+from benchbuild.extensions import compiler
+from benchbuild.utils import run
+
+
+class TraceBinaryCreator(base.Extension):
+    """
+    Create an additional binary with trace markers.
+    """
+
+    def __init__(self,
+                 project,
+                 experiment,
+                 marker_type,
+                 *extensions,
+                 extra_ldflags=None,
+                 config=None):
+        self.project = project
+        self.experiment = experiment
+        self.marker_type = marker_type
+        if extra_ldflags is None:
+            self.extra_ldflags = []
+        else:
+            self.extra_ldflags = extra_ldflags
+
+        super(TraceBinaryCreator, self).__init__(*extensions, config=config)
+
+    def __call__(self,
+                 command,
+                 *args,
+                 project=None,
+                 rerun_on_error=True,
+                 **kwargs):
+
+        res = self.call_next(command, *args, **kwargs)
+
+        for arg in args:
+            if arg.endswith(".cpp"):
+                src_file = arg
+                break
+
+        fake_file_name = src_file.replace(".cpp", "_fake.ll")
+
+        clang_stage_1 = command["-stdlib=libc++", "-fvara-handleRM=High", "-S",
+                                "-emit-llvm", "-o", fake_file_name, src_file]
+        with run.track_execution(clang_stage_1, self.project,
+                                 self.experiment) as _run:
+            res.append(_run())
+
+        opt = local["opt"]["-vara-HD", "-vara-trace", "-vara-trace-RTy=high",
+                           "-vara-trace-MTy={MType}".format(
+                               MType=self.marker_type
+                           ), "-S", "-o", "traced.ll", fake_file_name]
+        with run.track_execution(opt, self.project, self.experiment) as _run:
+            res.append(_run())
+
+        llc = local["llc"]["-filetype=obj", "-o", "traced.o", "traced.ll"]
+        with run.track_execution(llc, self.project, self.experiment) as _run:
+            res.append(_run())
+
+        clang_stage_2 = command["-O2", "traced.o", self.
+                                extra_ldflags, "-lSTrace", "-o",
+                                src_file.replace(".cpp", "_traced")]
+        with run.track_execution(clang_stage_2, self.project,
+                                 self.experiment) as _run:
+            res.append(_run())
+
+        return res
+
+
+class PrintMarkerInstTest(Experiment):
+    """
+    Instrumnet all highlight regions with print markers.
+    """
+
+    NAME = "PrintMarkerInstTest"
+
+    def actions_for_project(self, project):
+        project.compiler_extension = compiler.RunCompiler(project, self) \
+            << TraceBinaryCreator(project, self, "Print")
+
+        project.cflags = ["-fvara-handleRM=High"]
+
+        project_actions = self.default_compiletime_actions(project)
+
+        return project_actions
+
+
+class PapiMarkerInstTest(Experiment):
+    """
+    Instrumnet all highlight regions with papi markers.
+    """
+
+    NAME = "PapiMarkerInstTest"
+
+    def actions_for_project(self, project):
+        project.compiler_extension = compiler.RunCompiler(
+            project, self) << TraceBinaryCreator(
+                project,
+                self,
+                "Papi",
+                extra_ldflags=["-stdlib=libc++", "-lpthread", "-lpapi"])
+
+        project.cflags = ["-fvara-handleRM=High"]
+
+        project_actions = self.default_compiletime_actions(project)
+
+        return project_actions

--- a/varats/projects/c_projects/busybox.py
+++ b/varats/projects/c_projects/busybox.py
@@ -13,7 +13,7 @@ class busybox(Project):
     """ UNIX utility wrapper Busybox """
 
     NAME = 'busybox'
-    GROUP = 'code'
+    GROUP = 'c_projects'
     DOMAIN = 'UNIX utils'
     VERSION = 'HEAD'
 

--- a/varats/projects/c_projects/glibc.py
+++ b/varats/projects/c_projects/glibc.py
@@ -12,7 +12,7 @@ class Glibc(Project):
     """ Standard GNU C-library """
 
     NAME = 'glibc'
-    GROUP = 'code'
+    GROUP = 'c_projects'
     DOMAIN = 'UNIX utils'
     VERSION = 'HEAD'
 

--- a/varats/projects/c_projects/gravity.py
+++ b/varats/projects/c_projects/gravity.py
@@ -13,7 +13,7 @@ class Gravity(Project):
     """ Programming language Gravity """
 
     NAME = 'gravity'
-    GROUP = 'code'
+    GROUP = 'c_projects'
     DOMAIN = 'UNIX utils'
     VERSION = 'HEAD'
 

--- a/varats/projects/c_projects/gzip.py
+++ b/varats/projects/c_projects/gzip.py
@@ -13,8 +13,8 @@ class Gzip(prj.Project):
     """ Compression and decompression tool Gzip (fetched by Git) """
 
     NAME = 'gzip'
-    GROUP = 'git'
-    DOMAIN = 'version control'
+    GROUP = 'c_projects'
+    DOMAIN = 'VCS'
     VERSION = 'HEAD'
 
     SRC_FILE = NAME + "-{0}".format(VERSION)

--- a/varats/projects/c_projects/tmux.py
+++ b/varats/projects/c_projects/tmux.py
@@ -13,7 +13,7 @@ class Tmux(Project):
     """ Terminal multiplexer Tmux """
 
     NAME = 'tmux'
-    GROUP = 'code'
+    GROUP = 'c_projects'
     DOMAIN = 'UNIX utils'
     VERSION = 'HEAD'
 

--- a/varats/projects/c_projects/vim.py
+++ b/varats/projects/c_projects/vim.py
@@ -13,8 +13,8 @@ class Vim(Project):
     """ Text processing tool vim """
 
     NAME = 'vim'
-    GROUP = 'code'
-    DOMAIN = 'UNIX utils'
+    GROUP = 'c_projects'
+    DOMAIN = 'editor'
     VERSION = 'HEAD'
 
     SRC_FILE = NAME + "-{0}".format(VERSION)

--- a/varats/projects/cpp_projects/doxygen.py
+++ b/varats/projects/cpp_projects/doxygen.py
@@ -14,7 +14,7 @@ class Doxygen(Project):
     """ Doxygen """
 
     NAME = 'doxygen'
-    GROUP = 'code'
+    GROUP = 'cpp_projects'
     DOMAIN = 'documentation'
     VERSION = 'HEAD'
 

--- a/varats/projects/test_projects/basic_tests.py
+++ b/varats/projects/test_projects/basic_tests.py
@@ -1,0 +1,39 @@
+from plumbum import local
+
+from benchbuild.utils.run import run
+from benchbuild.utils.compiler import cxx
+from benchbuild.utils.download import with_git
+import benchbuild.project as prj
+
+
+@with_git(
+    "https://github.com/se-passau/vara-perf-tests.git",
+    limit=1,
+    refspec="HEAD")
+class BasicTests(prj.Project):
+    """
+    Basic tests:
+        Different small test files
+    """
+
+    NAME = 'basic-tests'
+    DOMAIN = 'testing'
+    GROUP = 'test_projects'
+
+    SRC_FILE = "vara-perf-tests"
+
+    test_files = [
+        "if.cpp", "loop.cpp", "switch.cpp", "exitOutsideRegion.cpp",
+        "overlappingRegions.cpp", "returnInRegion.cpp"
+    ]
+
+    def compile(self):
+        self.download()
+
+        clang = cxx(self)
+        with local.cwd(self.SRC_FILE + "/basic-tests"):
+            for test_file in self.test_files:
+                run(clang[test_file, "-o", test_file.replace('.cpp', '')])
+
+    def run_tests(self, runner):
+        pass

--- a/varats/settings.py
+++ b/varats/settings.py
@@ -137,7 +137,10 @@ def generate_benchbuild_config(vara_cfg, bb_config_path: str):
     # Experiments for VaRA
     projects_conf = BB_CFG["plugins"]["experiments"]
     projects_conf.value[:] = []
-    projects_conf.value[:] += ['varats.experiments.GitBlameAnnotationReport']
+    projects_conf.value[:] += [
+        'varats.experiments.GitBlameAnnotationReport',
+        'varats.experiments.marker_tester'
+    ]
 
     BB_CFG["env"] = {
         "PATH": [str(vara_cfg["llvm_install_dir"]) + "bin/"]


### PR DESCRIPTION
We add a basic-tests project for our own test cases to test runtime
parts. Furthermore, we added two tracer experiments that can add markers
to basic-tests binaries to test VaRAs automatic instrumentations.

related se-passau/VaRA#247