### PR TITLE
Initial case study tool with status

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,15 @@ paper_config:
 ```
 Next, we can run our experiment with BenchBuild as usual. During experiment execution BenchBuild will load our config and only evaluate the needed revisions.
 
+The current status of a case study can be visualized with `vara-cs status`:
+```console
+> vara-cs status -s
+CS: gzip_0: (0/5) processed
+CS: gzip_1: (2/5) processed
+CS: gzip_2: (5/5) processed
+CS: libvpx_0: (0/5) processed
+```
+
 ## Extending the tool suite
 VaRA-TS allows the user to extend it with different projects, experiments, and data representations.
 

--- a/setup.py
+++ b/setup.py
@@ -29,5 +29,6 @@ setup(name='VaRA-Tool-Suite',
           "console_scripts": [
               'vara-gen-graph = varats.driver:main_gen_graph',
               'vara-gen-bbconfig = varats.driver:main_gen_benchbuild_config',
+              'vara-cs = varats.driver:main_casestudy',
           ]
       })

--- a/tests/paper/test_case_study.py
+++ b/tests/paper/test_case_study.py
@@ -4,9 +4,6 @@ Test case study
 
 import unittest
 import yaml
-import mock
-
-from varats.data.commit_report import CommitReport
 
 YAML_CASE_STUDY = """!CaseStudy
 _CaseStudy__project_name: gzip
@@ -103,67 +100,3 @@ class TestCaseStudy(unittest.TestCase):
         self.assertFalse(
             revision_filter("42b25e7f1593f6dcc20660ff9fb1ed59ede15b7a"))
         self.assertFalse(revision_filter("42"))
-
-    @mock.patch('varats.paper.case_study.get_proccessed_revisions')
-    def test_get_short_status(self, mock_get_processed_revision):
-        """
-        Check if the case study can show a short status.
-        """
-        # Revision not in set
-        mock_get_processed_revision.return_value = ['42b25e7f15']
-
-        status = self.case_study.get_short_status(CommitReport)
-        self.assertEqual(status, 'CS: gzip_1: (0/10) processed')
-        mock_get_processed_revision.assert_called()
-
-        # Revision not in set
-        mock_get_processed_revision.reset_mock()
-        mock_get_processed_revision.return_value = ['b8b25e7f15']
-
-        status = self.case_study.get_short_status(CommitReport)
-        self.assertEqual(status, 'CS: gzip_1: (1/10) processed')
-        mock_get_processed_revision.assert_called()
-
-    @mock.patch('varats.paper.case_study.get_proccessed_revisions')
-    def test_get_status(self, mock_get_processed_revision):
-        """
-        Check if the case study can show a short status.
-        """
-        # Revision not in set
-        mock_get_processed_revision.return_value = ['42b25e7f15']
-
-        status = self.case_study.get_status(CommitReport)
-        self.assertEqual(
-            status, """CS: gzip_1: (0/10) processed
-    7620b81735 [Missing]
-    622e9b1d02 [Missing]
-    8798d5c4fd [Missing]
-    2e654f9963 [Missing]
-    edfad78619 [Missing]
-    a3db5806d0 [Missing]
-    e75f428c0d [Missing]
-    1e7e3769dc [Missing]
-    9872ba420c [Missing]
-    b8b25e7f15 [Missing]
-""")
-        mock_get_processed_revision.assert_called()
-
-        # Revision not in set
-        mock_get_processed_revision.reset_mock()
-        mock_get_processed_revision.return_value = ['b8b25e7f15', '2e654f9963']
-
-        status = self.case_study.get_status(CommitReport)
-        self.assertEqual(
-            status, """CS: gzip_1: (2/10) processed
-    7620b81735 [Missing]
-    622e9b1d02 [Missing]
-    8798d5c4fd [Missing]
-    2e654f9963 [OK     ]
-    edfad78619 [Missing]
-    a3db5806d0 [Missing]
-    e75f428c0d [Missing]
-    1e7e3769dc [Missing]
-    9872ba420c [Missing]
-    b8b25e7f15 [OK     ]
-""")
-        mock_get_processed_revision.assert_called()

--- a/tests/paper/test_case_study.py
+++ b/tests/paper/test_case_study.py
@@ -4,6 +4,9 @@ Test case study
 
 import unittest
 import yaml
+import mock
+
+from varats.data.commit_report import CommitReport
 
 YAML_CASE_STUDY = """!CaseStudy
 _CaseStudy__project_name: gzip
@@ -100,3 +103,67 @@ class TestCaseStudy(unittest.TestCase):
         self.assertFalse(
             revision_filter("42b25e7f1593f6dcc20660ff9fb1ed59ede15b7a"))
         self.assertFalse(revision_filter("42"))
+
+    @mock.patch('varats.paper.case_study.get_proccessed_revisions')
+    def test_get_short_status(self, mock_get_processed_revision):
+        """
+        Check if the case study can show a short status.
+        """
+        # Revision not in set
+        mock_get_processed_revision.return_value = ['42b25e7f15']
+
+        status = self.case_study.get_short_status(CommitReport)
+        self.assertEqual(status, 'CS: gzip_1: (0/10) processed')
+        mock_get_processed_revision.assert_called()
+
+        # Revision not in set
+        mock_get_processed_revision.reset_mock()
+        mock_get_processed_revision.return_value = ['b8b25e7f15']
+
+        status = self.case_study.get_short_status(CommitReport)
+        self.assertEqual(status, 'CS: gzip_1: (1/10) processed')
+        mock_get_processed_revision.assert_called()
+
+    @mock.patch('varats.paper.case_study.get_proccessed_revisions')
+    def test_get_status(self, mock_get_processed_revision):
+        """
+        Check if the case study can show a short status.
+        """
+        # Revision not in set
+        mock_get_processed_revision.return_value = ['42b25e7f15']
+
+        status = self.case_study.get_status(CommitReport)
+        self.assertEqual(
+            status, """CS: gzip_1: (0/10) processed
+    7620b81735 [Missing]
+    622e9b1d02 [Missing]
+    8798d5c4fd [Missing]
+    2e654f9963 [Missing]
+    edfad78619 [Missing]
+    a3db5806d0 [Missing]
+    e75f428c0d [Missing]
+    1e7e3769dc [Missing]
+    9872ba420c [Missing]
+    b8b25e7f15 [Missing]
+""")
+        mock_get_processed_revision.assert_called()
+
+        # Revision not in set
+        mock_get_processed_revision.reset_mock()
+        mock_get_processed_revision.return_value = ['b8b25e7f15', '2e654f9963']
+
+        status = self.case_study.get_status(CommitReport)
+        self.assertEqual(
+            status, """CS: gzip_1: (2/10) processed
+    7620b81735 [Missing]
+    622e9b1d02 [Missing]
+    8798d5c4fd [Missing]
+    2e654f9963 [OK     ]
+    edfad78619 [Missing]
+    a3db5806d0 [Missing]
+    e75f428c0d [Missing]
+    1e7e3769dc [Missing]
+    9872ba420c [Missing]
+    b8b25e7f15 [OK     ]
+""")
+        mock_get_processed_revision.assert_called()

--- a/tests/paper/test_paper_config_manager.py
+++ b/tests/paper/test_paper_config_manager.py
@@ -101,13 +101,13 @@ class TestPaperConfigManager(unittest.TestCase):
     7620b81735 [Missing]
     622e9b1d02 [Missing]
     8798d5c4fd [Missing]
-    2e654f9963 [OK     ]
+    2e654f9963 [OK]
     edfad78619 [Missing]
     a3db5806d0 [Missing]
     e75f428c0d [Missing]
     1e7e3769dc [Missing]
     9872ba420c [Missing]
-    b8b25e7f15 [OK     ]
+    b8b25e7f15 [OK]
 """)
         mock_get_processed_revision.assert_called()
 
@@ -148,12 +148,12 @@ class TestPaperConfigManager(unittest.TestCase):
     7620b81735 [Missing]
     622e9b1d02 [Missing]
     8798d5c4fd [Missing]
-    2e654f9963 [OK     ]
+    2e654f9963 [OK]
     edfad78619 [Missing]
     a3db5806d0 [Missing]
     e75f428c0d [Missing]
     1e7e3769dc [Missing]
     9872ba420c [Missing]
-    b8b25e7f15 [OK     ]
+    b8b25e7f15 [OK]
 """)
         mock_get_processed_revision.assert_called()

--- a/tests/paper/test_paper_config_manager.py
+++ b/tests/paper/test_paper_config_manager.py
@@ -1,0 +1,159 @@
+"""
+Test paper config manager
+"""
+
+import unittest
+import yaml
+import mock
+
+from varats.data.commit_report import CommitReport
+import varats.paper.paper_config_manager as PCM
+
+from test_case_study import YAML_CASE_STUDY
+
+
+class TestPaperConfigManager(unittest.TestCase):
+    """
+    Test basic PaperConfigManager functionality.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        Setup case study from yaml doc.
+        """
+        cls.case_study = yaml.safe_load(YAML_CASE_STUDY)
+
+    @mock.patch('varats.paper.case_study.get_proccessed_revisions')
+    def test_short_status(self, mock_get_processed_revision):
+        """
+        Check if the case study can show a short status.
+        """
+        # Revision not in set
+        mock_get_processed_revision.return_value = ['42b25e7f15']
+
+        status = PCM.get_short_status(self.case_study, CommitReport)
+        self.assertEqual(status, 'CS: gzip_1: (0/10) processed')
+        mock_get_processed_revision.assert_called()
+
+        # Revision not in set
+        mock_get_processed_revision.reset_mock()
+        mock_get_processed_revision.return_value = ['b8b25e7f15']
+
+        status = PCM.get_short_status(self.case_study, CommitReport)
+        self.assertEqual(status, 'CS: gzip_1: (1/10) processed')
+        mock_get_processed_revision.assert_called()
+
+    @mock.patch('varats.paper.case_study.get_proccessed_revisions')
+    def test_short_status_color(self, mock_get_processed_revision):
+        """
+        Check if the case study can show a short status.
+
+        Currently this only checks if the output is correctly generated but
+        not if the colors are present.
+        """
+        # Revision not in set
+        mock_get_processed_revision.return_value = ['42b25e7f15']
+
+        status = PCM.get_short_status(self.case_study, CommitReport, True)
+        self.assertEqual(status, 'CS: gzip_1: (0/10) processed')
+        mock_get_processed_revision.assert_called()
+
+        # Revision not in set
+        mock_get_processed_revision.reset_mock()
+        mock_get_processed_revision.return_value = ['b8b25e7f15']
+
+        status = PCM.get_short_status(self.case_study, CommitReport, True)
+        self.assertEqual(status, 'CS: gzip_1: (1/10) processed')
+        mock_get_processed_revision.assert_called()
+
+    @mock.patch('varats.paper.case_study.get_proccessed_revisions')
+    def test_status(self, mock_get_processed_revision):
+        """
+        Check if the case study can show a short status.
+        """
+        # Revision not in set
+        mock_get_processed_revision.return_value = ['42b25e7f15']
+
+        status = PCM.get_status(self.case_study, CommitReport)
+        self.assertEqual(
+            status, """CS: gzip_1: (0/10) processed
+    7620b81735 [Missing]
+    622e9b1d02 [Missing]
+    8798d5c4fd [Missing]
+    2e654f9963 [Missing]
+    edfad78619 [Missing]
+    a3db5806d0 [Missing]
+    e75f428c0d [Missing]
+    1e7e3769dc [Missing]
+    9872ba420c [Missing]
+    b8b25e7f15 [Missing]
+""")
+        mock_get_processed_revision.assert_called()
+
+        # Revision not in set
+        mock_get_processed_revision.reset_mock()
+        mock_get_processed_revision.return_value = ['b8b25e7f15', '2e654f9963']
+
+        status = PCM.get_status(self.case_study, CommitReport)
+        self.assertEqual(
+            status, """CS: gzip_1: (2/10) processed
+    7620b81735 [Missing]
+    622e9b1d02 [Missing]
+    8798d5c4fd [Missing]
+    2e654f9963 [OK     ]
+    edfad78619 [Missing]
+    a3db5806d0 [Missing]
+    e75f428c0d [Missing]
+    1e7e3769dc [Missing]
+    9872ba420c [Missing]
+    b8b25e7f15 [OK     ]
+""")
+        mock_get_processed_revision.assert_called()
+
+    @mock.patch('varats.paper.case_study.get_proccessed_revisions')
+    def test_status_color(self, mock_get_processed_revision):
+        """
+        Check if the case study can show a short status.
+
+        Currently this only checks if the output is correctly generated but
+        not if the colors are present.
+        """
+        # Revision not in set
+        mock_get_processed_revision.return_value = ['42b25e7f15']
+
+        status = PCM.get_status(self.case_study, CommitReport, True)
+        self.assertEqual(
+            status, """CS: gzip_1: (0/10) processed
+    7620b81735 [Missing]
+    622e9b1d02 [Missing]
+    8798d5c4fd [Missing]
+    2e654f9963 [Missing]
+    edfad78619 [Missing]
+    a3db5806d0 [Missing]
+    e75f428c0d [Missing]
+    1e7e3769dc [Missing]
+    9872ba420c [Missing]
+    b8b25e7f15 [Missing]
+""")
+        mock_get_processed_revision.assert_called()
+
+        # Revision not in set
+        mock_get_processed_revision.reset_mock()
+        mock_get_processed_revision.return_value = ['b8b25e7f15', '2e654f9963']
+
+        status = PCM.get_status(self.case_study, CommitReport, True)
+        self.assertEqual(
+            status, """CS: gzip_1: (2/10) processed
+    7620b81735 [Missing]
+    622e9b1d02 [Missing]
+    8798d5c4fd [Missing]
+    2e654f9963 [OK     ]
+    edfad78619 [Missing]
+    a3db5806d0 [Missing]
+    e75f428c0d [Missing]
+    1e7e3769dc [Missing]
+    9872ba420c [Missing]
+    b8b25e7f15 [OK     ]
+""")
+        mock_get_processed_revision.assert_called()

--- a/varats/data/revisions.py
+++ b/varats/data/revisions.py
@@ -1,0 +1,30 @@
+"""
+Module for handling the state of project revisions in VaRA.
+"""
+
+from pathlib import Path
+
+from varats.settings import CFG
+
+
+def get_proccessed_revisions(project_name: str, result_file_type) -> [str]:
+    """
+    Calculates a list of revisions of a project that have already
+    been processed.
+
+    Args:
+        project_name: target project
+        result_file_type: the type of the result file
+    """
+    res_dir = Path("{result_folder}/{project_name}/".format(
+        result_folder=CFG["result_dir"], project_name=project_name))
+
+    processed_revision = []
+    if res_dir.exists():
+        for res_file in res_dir.iterdir():
+            if not str(res_file.stem).startswith("{}-".format(project_name)):
+                continue
+            match = result_file_type.FILE_NAME_REGEX.search(res_file.stem)
+            processed_revision.append(match.group("file_commit_hash"))
+
+    return processed_revision

--- a/varats/driver.py
+++ b/varats/driver.py
@@ -21,6 +21,7 @@ from varats.plots.plots import extend_parser_with_plot_args, build_plot
 from varats.utils.cli_util import cli_yn_choice
 from varats.paper.case_study import SamplingMethod, generate_case_study,\
     store_case_study
+import varats.paper.paper_config_manager as PCM
 
 from PyQt5.QtWidgets import QApplication, QMessageBox
 
@@ -239,6 +240,8 @@ def main_gen_commitmap():
     cs_parser = sub_parsers.add_parser(
         'case-study', help="Generate a case study.")
     cs_parser.add_argument("distribution", action=enum_action(SamplingMethod))
+    # TODO (se-passau/VaRA#410): this needs to be a full path to the paper
+    #                            folder + config
     cs_parser.add_argument("paper_path", help="Path to paper folder.")
     cs_parser.add_argument(
         "--num-rev",
@@ -281,3 +284,36 @@ def main_gen_commitmap():
             else:
                 output_name = args.output + ".cmap"
         store_commit_map(cmap, output_name)
+
+
+def main_casestudy():
+    """
+    Allow easier management of case studies
+    """
+    parser = argparse.ArgumentParser("VaRA case-study manager")
+    sub_parsers = parser.add_subparsers(help="Subcommand", dest="subcommand")
+
+    status_parser = sub_parsers.add_parser(
+        'status', help="Show status of current case study")
+    status_parser.add_argument(
+        "--filter-regex",
+        help="Provide a regex to filter the shown case studies",
+        type=str,
+        default=".*")
+    status_parser.add_argument(
+        "--paper_config",
+        help="Use this paper config instead of the configured one",
+        default=None)
+    status_parser.add_argument(
+        "-s",
+        "--short",
+        help="Only print a short summary",
+        action="store_true",
+        default=False)
+
+    args = parser.parse_args()
+    if args.subcommand == 'status':
+        if args.paper_config is not None:
+            CFG['paper_config']['current_config'] = args.paper_config
+
+        PCM.show_status_of_case_studies(args.filter_regex, args.short)

--- a/varats/experiments/GitBlameAnnotationReport.py
+++ b/varats/experiments/GitBlameAnnotationReport.py
@@ -17,10 +17,11 @@ from benchbuild.settings import CFG
 from benchbuild.utils.cmd import opt, mkdir
 import benchbuild.utils.actions as actions
 
+from varats.data.commit_report import CommitReport as CR
+from varats.data.revisions import get_proccessed_revisions
 from varats.experiments.Extract import Extract
 from varats.experiments.Wllvm import RunWLLVM
 from varats.settings import CFG as V_CFG
-from varats.data.commit_report import CommitReport as CR
 
 
 class CFRAnalysis(actions.Step):
@@ -143,21 +144,10 @@ class GitBlameAnntotationReport(Experiment):
             random.shuffle(versions)
 
         if bool(V_CFG["experiment"]["only_missing"]):
-            res_dir = Path("{result_folder}/{project_name}/"
-                           .format(result_folder=V_CFG["result_dir"],
-                                   project_name=str(prj_cls.NAME)))
-
-            processed_version = []
-            if res_dir.exists():
-                for res_file in res_dir.iterdir():
-                    if not str(res_file.stem).startswith(
-                            "{}-".format(prj_cls.NAME)):
-                        continue
-                    match = CR.FILE_NAME_REGEX.search(res_file.stem)
-                    processed_version.append(match.group("file_commit_hash"))
-
-            versions = [vers for vers in versions
-                        if vers not in processed_version]
+            versions = [
+                vers for vers in versions
+                if vers not in get_proccessed_revisions(prj_cls.NAME, CR)
+            ]
             if not versions:
                 print("Could not find any unprocessed versions.")
                 return

--- a/varats/paper/case_study.py
+++ b/varats/paper/case_study.py
@@ -128,43 +128,25 @@ class CaseStudy(yaml.YAMLObject):
 
         return revision_filter
 
-    def get_short_status(self, result_file_type,
-                         processed_revisions=None) -> str:
+    def processed_revisions(self, result_file_type) -> [str]:
         """
-        Return a string representation that describes the current status of
-        the case study.
+        Calculate how many revisions were processed.
         """
         total_processed_revisions = set(
-            processed_revisions if processed_revisions is not None else
             get_proccessed_revisions(self.project_name, result_file_type))
 
-        num_pr_for_case_study = 0
-        for rev in self.revisions:
-            if rev[:10] in total_processed_revisions:
-                num_pr_for_case_study += 1
+        return [
+            rev for rev in self.revisions
+            if rev[:10] in total_processed_revisions
+        ]
 
-        status = "CS: {project}_{version}: ".format(
-            project=self.project_name, version=self.version)
-        status += "({processed}/{total}) processed".format(
-            processed=num_pr_for_case_study, total=len(self.revisions))
-        return status
-
-    def get_status(self, result_file_type) -> str:
+    def get_revisions_status(self, result_file_type) -> [(str, str)]:
         """
-        Return a string representation that describes the current status of
-        the case study.
+        Get status of all revisions.
         """
-        total_processed_revisions = get_proccessed_revisions(
-            self.project_name, result_file_type)
-
-        status = self.get_short_status(result_file_type,
-                                       total_processed_revisions) + "\n"
-        for rev in self.revisions:
-            state = "OK" if rev[:10] in total_processed_revisions \
-                else "Missing"
-            status += "    {rev} [{status:7s}]\n".format(
-                rev=rev[:10], status=state)
-        return status
+        processed_revisions = self.processed_revisions(result_file_type)
+        return [(rev[:10], "OK" if rev in processed_revisions else "Missing")
+                for rev in self.revisions]
 
 
 ###############################################################################

--- a/varats/paper/case_study.py
+++ b/varats/paper/case_study.py
@@ -9,6 +9,8 @@ from enum import Enum
 from numpy import random
 from scipy.stats import halfnorm
 
+from varats.data.revisions import get_proccessed_revisions
+
 
 class HashIDTuple(yaml.YAMLObject):
     """
@@ -125,6 +127,44 @@ class CaseStudy(yaml.YAMLObject):
             return self.has_revision(revision)
 
         return revision_filter
+
+    def get_short_status(self, result_file_type,
+                         processed_revisions=None) -> str:
+        """
+        Return a string representation that describes the current status of
+        the case study.
+        """
+        total_processed_revisions = set(
+            processed_revisions if processed_revisions is not None else
+            get_proccessed_revisions(self.project_name, result_file_type))
+
+        num_pr_for_case_study = 0
+        for rev in self.revisions:
+            if rev[:10] in total_processed_revisions:
+                num_pr_for_case_study += 1
+
+        status = "CS: {project}_{version}: ".format(
+            project=self.project_name, version=self.version)
+        status += "({processed}/{total}) processed".format(
+            processed=num_pr_for_case_study, total=len(self.revisions))
+        return status
+
+    def get_status(self, result_file_type) -> str:
+        """
+        Return a string representation that describes the current status of
+        the case study.
+        """
+        total_processed_revisions = get_proccessed_revisions(
+            self.project_name, result_file_type)
+
+        status = self.get_short_status(result_file_type,
+                                       total_processed_revisions) + "\n"
+        for rev in self.revisions:
+            state = "OK" if rev[:10] in total_processed_revisions \
+                else "Missing"
+            status += "    {rev} [{status:7s}]\n".format(
+                rev=rev[:10], status=state)
+        return status
 
 
 ###############################################################################

--- a/varats/paper/paper_config.py
+++ b/varats/paper/paper_config.py
@@ -38,6 +38,15 @@ class PaperConfig():
         """
         return self.__case_studies[cs_name]
 
+    def get_all_case_studies(self):
+        """
+        Returns a full list of all case studies with all different version.
+        """
+        return [
+            case_study for case_study_list in self.__case_studies.values()
+            for case_study in case_study_list
+        ]
+
     def has_case_study(self, cs_name):
         """
         Check if a case study with `cs_name` was loaded.

--- a/varats/paper/paper_config_manager.py
+++ b/varats/paper/paper_config_manager.py
@@ -82,6 +82,6 @@ def get_status(case_study, result_file_type, use_color=False):
             return rev_state
 
     for rev_state in case_study.get_revisions_status(result_file_type):
-        status += "    {rev} [{status:7s}]\n".format(
+        status += "    {rev} [{status}]\n".format(
             rev=rev_state[0], status=color_rev_state(rev_state[1]))
     return status

--- a/varats/paper/paper_config_manager.py
+++ b/varats/paper/paper_config_manager.py
@@ -1,0 +1,35 @@
+"""
+Module for interacting with paper configs.
+"""
+
+import re
+
+from varats.data.commit_report import CommitReport
+from varats.settings import CFG
+import varats.paper.paper_config as PC
+
+
+def show_status_of_case_studies(filter_regex: str, short_status: bool):
+    """
+    Show the status of all matching case studies.
+    """
+    print("Searching with regex: ", filter_regex)
+
+    # load paper config
+    PC.load_paper_config(
+        str(CFG["paper_config"]["folder"]) + "/" +
+        str(CFG["paper_config"]["current_config"]))
+
+    current_config = PC.get_paper_config()
+
+    for case_study in sorted(
+            current_config.get_all_case_studies(),
+            key=lambda cs: (cs.project_name, cs.version)):
+        match = re.match(
+            filter_regex, "{name}_{version}".format(
+                name=case_study.project_name, version=case_study.version))
+        if match is not None:
+            if short_status:
+                print(case_study.get_short_status(CommitReport))
+            else:
+                print(case_study.get_status(CommitReport))

--- a/varats/paper/paper_config_manager.py
+++ b/varats/paper/paper_config_manager.py
@@ -4,6 +4,8 @@ Module for interacting with paper configs.
 
 import re
 
+from plumbum import colors
+
 from varats.data.commit_report import CommitReport
 from varats.settings import CFG
 import varats.paper.paper_config as PC
@@ -13,9 +15,6 @@ def show_status_of_case_studies(filter_regex: str, short_status: bool):
     """
     Show the status of all matching case studies.
     """
-    print("Searching with regex: ", filter_regex)
-
-    # load paper config
     PC.load_paper_config(
         str(CFG["paper_config"]["folder"]) + "/" +
         str(CFG["paper_config"]["current_config"]))
@@ -30,6 +29,59 @@ def show_status_of_case_studies(filter_regex: str, short_status: bool):
                 name=case_study.project_name, version=case_study.version))
         if match is not None:
             if short_status:
-                print(case_study.get_short_status(CommitReport))
+                print(get_short_status(case_study, CommitReport, True))
             else:
-                print(case_study.get_status(CommitReport))
+                print(get_status(case_study, CommitReport, True))
+
+
+def get_short_status(case_study, result_file_type, use_color=False):
+    """
+    Return a string representation that describes the current status of
+    the case study.
+    """
+
+    processed_revisions = case_study.processed_revisions(result_file_type)
+
+    status = "CS: {project}_{version}: ".format(
+        project=case_study.project_name, version=case_study.version)
+
+    num_p_rev = len(processed_revisions)
+    num_rev = len(case_study.revisions)
+
+    color = None
+    if use_color:
+        if num_p_rev == num_rev:
+            color = colors.green
+        elif num_p_rev == 0:
+            color = colors.red
+        else:
+            color = colors.orange3
+
+    if color is not None:
+        status += "(" + color["{processed}/{total}".format(
+            processed=num_p_rev, total=num_rev)] + ") processed"
+    else:
+        status += "({processed}/{total}) processed".format(
+            processed=num_p_rev, total=num_rev)
+
+    return status
+
+
+def get_status(case_study, result_file_type, use_color=False):
+    """
+    Return a string representation that describes the current status of
+    the case study.
+    """
+    status = get_short_status(case_study, result_file_type, use_color) + "\n"
+
+    def color_rev_state(rev_state):
+        if use_color:
+            return colors.green[
+                rev_state] if rev_state == "OK" else colors.red[rev_state]
+        else:
+            return rev_state
+
+    for rev_state in case_study.get_revisions_status(result_file_type):
+        status += "    {rev} [{status:7s}]\n".format(
+            rev=rev_state[0], status=color_rev_state(rev_state[1]))
+    return status


### PR DESCRIPTION
Initial case-study tool implementation to allow easier handling of case studies.
Currently we support: status (to print the current state)

resolves se-passau/VaRA#402
related se-passau/VaRA#410