### PR TITLE
Fix 'vara-cs status' crash

### DIFF
--- a/varats/data/revisions.py
+++ b/varats/data/revisions.py
@@ -25,6 +25,7 @@ def get_proccessed_revisions(project_name: str, result_file_type) -> [str]:
             if not str(res_file.stem).startswith("{}-".format(project_name)):
                 continue
             match = result_file_type.FILE_NAME_REGEX.search(res_file.stem)
-            processed_revision.append(match.group("file_commit_hash"))
+            if match:
+                processed_revision.append(match.group("file_commit_hash"))
 
     return processed_revision


### PR DESCRIPTION
vara-cs status used to crash if the result directory
contains a file that starts with the project name but does
not conform to the result file name regex.