### PR TITLE
Add feature to add n revisions per year to a case-study

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
         "plumbum>=1.6.6",
         "wllvm>=1.1.4",
         "argparse-utils>=1.2.0",
+        "pygit2>=0.28.2",
     ],
     author="Florian Sattler",
     author_email="sattlerf@fim.uni-passau.de",

--- a/varats/driver.py
+++ b/varats/driver.py
@@ -375,6 +375,11 @@ def main_casestudy():
             default=[],
             help="Add a list of additional revisions to the case-study")
         sub_parser.add_argument(
+            "--revs-per-year",
+            type=int,
+            default=0,
+            help="Add this many revisions per year to the case-study.")
+        sub_parser.add_argument(
             "--num-rev",
             type=int,
             default=10,
@@ -449,7 +454,7 @@ def main_casestudy():
         cmap = generate_commit_map(git_path, args['end'],
                                    args['start'] if 'start' in args else None)
 
-        args['git_path'] = git_path.stem.replace("-HEAD", "")
+        args['project_name'] = git_path.stem.replace("-HEAD", "")
         if args['subcommand'] == 'ext':
             case_study = load_case_study_from_file(
                 Path(args['case_study_path']))
@@ -482,7 +487,7 @@ def main_casestudy():
             args['merge_stage'] = 0
 
             case_study = generate_case_study(
-                args['distribution'], args['num_rev'], cmap, args['git_path'],
+                args['distribution'], args['num_rev'], cmap, args['project_name'],
                 args['version'], **args)
 
             store_case_study(case_study, args['paper_config_path'])

--- a/varats/driver.py
+++ b/varats/driver.py
@@ -487,8 +487,7 @@ def main_casestudy():
             args['merge_stage'] = 0
 
             case_study = generate_case_study(
-                args['distribution'], args['num_rev'], cmap, args['project_name'],
-                args['version'], **args)
+                args['distribution'], args['num_rev'], cmap, args['version'], **args)
 
             store_case_study(case_study, args['paper_config_path'])
 

--- a/varats/paper/case_study.py
+++ b/varats/paper/case_study.py
@@ -322,7 +322,7 @@ class SamplingMethod(Enum):
 
 @check_required_args(['extra_revs', 'git_path', 'revs_per_year'])
 def generate_case_study(sampling_method: SamplingMethod, num_samples: int,
-                        cmap, proj_name: str, case_study_version: int,
+                        cmap, case_study_version: int, project_name: str,
                         **kwargs) -> CaseStudy:
     """
     Generate a case study for a given project.
@@ -331,7 +331,7 @@ def generate_case_study(sampling_method: SamplingMethod, num_samples: int,
     given project and persists the selected set into a case study for
     evaluation.
     """
-    case_study = CaseStudy(proj_name, case_study_version)
+    case_study = CaseStudy(project_name, case_study_version)
 
     if kwargs['extra_revs']:
         extend_with_extra_revs(case_study, cmap, **kwargs)

--- a/varats/paper/case_study.py
+++ b/varats/paper/case_study.py
@@ -3,14 +3,18 @@ A case study to pin down project settings and the exact set of revisions that
 should be analysed.
 """
 
+from collections import defaultdict
+from datetime import datetime
 from enum import Enum
 from pathlib import Path
 import errno
 import os
+import random
 import yaml
 
-from numpy import random
 from scipy.stats import halfnorm
+import numpy as np
+import pygit2
 
 from varats.data.revisions import get_proccessed_revisions
 from varats.plots.plot_utils import check_required_args
@@ -303,7 +307,7 @@ class SamplingMethod(Enum):
         if self == SamplingMethod.uniform:
 
             def uniform(num_samples):
-                return random.uniform(0, 1.0, num_samples)
+                return np.random.uniform(0, 1.0, num_samples)
 
             return uniform
         if self == SamplingMethod.half_norm:
@@ -316,9 +320,9 @@ class SamplingMethod(Enum):
         raise Exception('Unsupported SamplingMethod')
 
 
-@check_required_args(['extra_revs'])
+@check_required_args(['extra_revs', 'git_path', 'revs_per_year'])
 def generate_case_study(sampling_method: SamplingMethod, num_samples: int,
-                        cmap, project_name: str, case_study_version: int,
+                        cmap, proj_name: str, case_study_version: int,
                         **kwargs) -> CaseStudy:
     """
     Generate a case study for a given project.
@@ -327,10 +331,13 @@ def generate_case_study(sampling_method: SamplingMethod, num_samples: int,
     given project and persists the selected set into a case study for
     evaluation.
     """
-    case_study = CaseStudy(project_name, case_study_version)
+    case_study = CaseStudy(proj_name, case_study_version)
 
     if kwargs['extra_revs']:
         extend_with_extra_revs(case_study, cmap, **kwargs)
+
+    if kwargs['revs_per_year'] > 0:
+        extend_with_revs_per_year(case_study, cmap, **kwargs)
 
     extend_with_distrib_sampling(case_study, cmap, **kwargs)
 
@@ -350,6 +357,7 @@ class ExtenderStrategy(Enum):
     simple_add = 1
     distrib_add = 2
     smooth_plot = 3
+    per_year_add = 4
 
 
 def extend_case_study(case_study: CaseStudy, cmap,
@@ -364,6 +372,8 @@ def extend_case_study(case_study: CaseStudy, cmap,
         extend_with_distrib_sampling(case_study, cmap, **kwargs)
     elif ext_strategy is ExtenderStrategy.smooth_plot:
         extend_with_smooth_revs(case_study, cmap, **kwargs)
+    elif ext_strategy is ExtenderStrategy.per_year_add:
+        extend_with_revs_per_year(case_study, cmap, **kwargs)
 
 
 @check_required_args(['extra_revs', 'merge_stage'])
@@ -380,6 +390,33 @@ def extend_with_extra_revs(case_study: CaseStudy, cmap, **kwargs):
     ]
 
     case_study.include_revisions(new_rev_items, merge_stage, True)
+
+
+@check_required_args(['git_path', 'revs_per_year', 'merge_stage'])
+def extend_with_revs_per_year(case_study: CaseStudy, cmap, **kwargs):
+    """
+    Extend a case_study with n revisions per year.
+    """
+    repo_path = pygit2.discover_repository(kwargs['git_path'])
+    repo = pygit2.Repository(repo_path)
+    last_commit = repo[repo.head.target]
+
+    commits = defaultdict(list) # maps year -> list of commits
+    for commit in repo.walk(last_commit.id, pygit2.GIT_SORT_TIME):
+        commit_date = datetime.utcfromtimestamp(commit.commit_time)
+        commits[commit_date.year].append(str(commit.id))
+
+    new_rev_items = [] # new revisions that get added to to case_study
+    for _, commits_in_year in commits.items():
+        samples = min(len(commits_in_year), kwargs['revs_per_year'])
+        sample_commit_indices = sorted(random.sample(range(len(commits_in_year)), samples))
+
+        for commit_index in sample_commit_indices:
+            commit_hash = commits_in_year[commit_index]
+            time_id = cmap.time_id(commit_hash)
+            new_rev_items.append((commit_hash, time_id))
+
+    case_study.include_revisions(new_rev_items, kwargs['merge_stage'], True)
 
 
 @check_required_args(['distribution', 'merge_stage', 'num_rev'])
@@ -416,7 +453,7 @@ def sample_n_idxs(distrib_func, num_samples, list_to_sample: []) -> []:
     probabilities = distrib_func(len(list_to_sample))
     probabilities /= probabilities.sum()
 
-    sampled_idxs = random.choice(
+    sampled_idxs = np.random.choice(
         len(list_to_sample), num_samples, p=probabilities)
 
     return [list_to_sample[idx] for idx in sampled_idxs]


### PR DESCRIPTION
`vara-cs gen` now has a new parameter `--revs-per-year`.
It works similar to the `--extra-revs` parameter in that it adds revisions to the case-study before the
actual sampling step.
The revisions per year are sampled uniformly.
For example `--revs-per-year 5` means that for each year, 5 revisions are sampled uniformly.