### PR TITLE
Show failed projects in vara-cs status

### DIFF
--- a/varats/data/commit_report.py
+++ b/varats/data/commit_report.py
@@ -125,9 +125,9 @@ class FunctionGraphEdges():
 
 class CommitReport():
 
-    FILE_NAME_REGEX = re.compile(r"(?P<project_name>.*)-(?P<binary_name>.*)-" +
-                                 r"(?P<file_commit_hash>.*)_(?P<UUID>[0-9a-fA-F\-]*)" +
-                                 r"(?P<EXT>(\.yaml|\.failed))$")
+    __FILE_NAME_REGEX = re.compile(r"(?P<project_name>.*)-(?P<binary_name>.*)-" +
+                                   r"(?P<file_commit_hash>.*)_(?P<UUID>[0-9a-fA-F\-]*)" +
+                                   r"(?P<EXT>(\.yaml|\.failed))$")
 
     def __init__(self, path: str):
         with open(path, "r") as stream:
@@ -159,18 +159,33 @@ class CommitReport():
 
     @staticmethod
     def is_result_file(file_name: str) -> bool:
-        match = CommitReport.FILE_NAME_REGEX.search(file_name)
+        """ Check if the passed file name is a result file. """
+        match = CommitReport.__FILE_NAME_REGEX.search(file_name)
         return match
 
     @staticmethod
     def is_result_file_success(file_name: str) -> bool:
-        match = CommitReport.FILE_NAME_REGEX.search(file_name)
-        return match.group("EXT") == ".yaml"
+        """ Check if the passed file name is a (successful) result file. """
+        match = CommitReport.__FILE_NAME_REGEX.search(file_name)
+        if match:
+            return match.group("EXT") == ".yaml"
+        return False
 
     @staticmethod
     def is_result_file_failed(file_name: str) -> bool:
-        match = CommitReport.FILE_NAME_REGEX.search(file_name)
-        return match.group("EXT") == ".failed"
+        """ Check if the passed file name is a (failed) result file. """
+        match = CommitReport.__FILE_NAME_REGEX.search(file_name)
+        if match:
+            return match.group("EXT") == ".failed"
+        return False
+
+    @staticmethod
+    def get_commit_hash_from_result_file(file_name: str) -> str:
+        """ Get the commit hash from a result file name. """
+        match = CommitReport.__FILE_NAME_REGEX.search(file_name)
+        if match:
+            return match.group("file_commit_hash")
+        return None
 
     @property
     def path(self) -> str:
@@ -184,7 +199,7 @@ class CommitReport():
         """
         The current HEAD commit under which this CommitReport was created.
         """
-        match = self.FILE_NAME_REGEX.search(Path(self._path).name)
+        match = self.__FILE_NAME_REGEX.search(Path(self._path).name)
         return match.group("file_commit_hash")
 
     def calc_max_cf_edges(self):

--- a/varats/data/commit_report.py
+++ b/varats/data/commit_report.py
@@ -125,12 +125,9 @@ class FunctionGraphEdges():
 
 class CommitReport():
 
-    FILE_STEM_REGEX = re.compile(r"(?P<project_name>.*)-(?P<binary_name>.*)-" +
-                                 "(?P<file_commit_hash>.*)_(?P<UUID>.*)")
-    FILE_NAME_SUCCESS_REGEX = re.compile(r"(?P<project_name>.*)-(?P<binary_name>.*)-" +
-                                 "(?P<file_commit_hash>.*)_(?P<UUID>.*).yaml")
-    FILE_NAME_FAILED_REGEX = re.compile(r"(?P<project_name>.*)-(?P<binary_name>.*)-" +
-                                 "(?P<file_commit_hash>.*)_(?P<UUID>.*).failed")
+    FILE_NAME_REGEX = re.compile(r"(?P<project_name>.*)-(?P<binary_name>.*)-" +
+                                 r"(?P<file_commit_hash>.*)_(?P<UUID>[0-9a-fA-F\-]*)" +
+                                 r"(?P<EXT>(\.yaml|\.failed))$")
 
     def __init__(self, path: str):
         with open(path, "r") as stream:
@@ -160,6 +157,21 @@ class CommitReport():
                 f_edge = FunctionGraphEdges(raw_fg_edge)
                 self.graph_info[f_edge.fid] = f_edge
 
+    @staticmethod
+    def is_result_file(file_name: str) -> bool:
+        match = CommitReport.FILE_NAME_REGEX.search(file_name)
+        return match
+
+    @staticmethod
+    def is_result_file_success(file_name: str) -> bool:
+        match = CommitReport.FILE_NAME_REGEX.search(file_name)
+        return match.group("EXT") == ".yaml"
+
+    @staticmethod
+    def is_result_file_failed(file_name: str) -> bool:
+        match = CommitReport.FILE_NAME_REGEX.search(file_name)
+        return match.group("EXT") == ".failed"
+
     @property
     def path(self) -> str:
         """
@@ -172,7 +184,7 @@ class CommitReport():
         """
         The current HEAD commit under which this CommitReport was created.
         """
-        match = self.FILE_STEM_REGEX.search(Path(self._path).stem)
+        match = self.FILE_NAME_REGEX.search(Path(self._path).name)
         return match.group("file_commit_hash")
 
     def calc_max_cf_edges(self):

--- a/varats/data/commit_report.py
+++ b/varats/data/commit_report.py
@@ -125,8 +125,12 @@ class FunctionGraphEdges():
 
 class CommitReport():
 
-    FILE_NAME_REGEX = re.compile(r"(?P<project_name>.*)-(?P<binary_name>.*)-" +
+    FILE_STEM_REGEX = re.compile(r"(?P<project_name>.*)-(?P<binary_name>.*)-" +
                                  "(?P<file_commit_hash>.*)_(?P<UUID>.*)")
+    FILE_NAME_SUCCESS_REGEX = re.compile(r"(?P<project_name>.*)-(?P<binary_name>.*)-" +
+                                 "(?P<file_commit_hash>.*)_(?P<UUID>.*).yaml")
+    FILE_NAME_FAILED_REGEX = re.compile(r"(?P<project_name>.*)-(?P<binary_name>.*)-" +
+                                 "(?P<file_commit_hash>.*)_(?P<UUID>.*).failed")
 
     def __init__(self, path: str):
         with open(path, "r") as stream:
@@ -168,7 +172,7 @@ class CommitReport():
         """
         The current HEAD commit under which this CommitReport was created.
         """
-        match = self.FILE_NAME_REGEX.search(Path(self._path).stem)
+        match = self.FILE_STEM_REGEX.search(Path(self._path).stem)
         return match.group("file_commit_hash")
 
     def calc_max_cf_edges(self):

--- a/varats/data/revisions.py
+++ b/varats/data/revisions.py
@@ -2,15 +2,16 @@
 Module for handling the state of project revisions in VaRA.
 """
 
+from collections import defaultdict
 from pathlib import Path
+from typing import Dict
 
 from varats.settings import CFG
 
 
-def get_proccessed_revisions(project_name: str, result_file_type) -> [str]:
+def __get_result_files_dict(project_name: str, result_file_type) -> Dict:
     """
-    Calculates a list of revisions of a project that have already
-    been processed.
+    Returns a dict that maps the commit_hash to a list of all result files for that commit.
 
     Args:
         project_name: target project
@@ -19,13 +20,54 @@ def get_proccessed_revisions(project_name: str, result_file_type) -> [str]:
     res_dir = Path("{result_folder}/{project_name}/".format(
         result_folder=CFG["result_dir"], project_name=project_name))
 
-    processed_revision = []
+    result_files = defaultdict(list) # maps commit hash -> list of res files (success or fail)
     if res_dir.exists():
         for res_file in res_dir.iterdir():
             if not str(res_file.stem).startswith("{}-".format(project_name)):
                 continue
-            match = result_file_type.FILE_NAME_REGEX.search(res_file.stem)
+            match = result_file_type.FILE_STEM_REGEX.search(res_file.stem)
             if match:
-                processed_revision.append(match.group("file_commit_hash"))
+                result_files[match.group("file_commit_hash")].append(res_file)
 
-    return processed_revision
+    return result_files
+
+
+def get_proccessed_revisions(project_name: str, result_file_type) -> [str]:
+    """
+    Calculates a list of revisions of a project that have already
+    been processed successfully.
+
+    Args:
+        project_name: target project
+        result_file_type: the type of the result file
+    """
+    processed_revisions = []
+
+    result_files = __get_result_files_dict(project_name, result_file_type)
+    for _, value in result_files.items():
+        newest_res_file = max(value, key=lambda x: Path(x).stat().st_mtime)
+        match = result_file_type.FILE_NAME_SUCCESS_REGEX.search(newest_res_file.name)
+        if match:
+            processed_revisions.append(match.group("file_commit_hash"))
+
+    return processed_revisions
+
+
+def get_failed_revisions(project_name: str, result_file_type) -> [str]:
+    """
+    Calculates a list of revisions of a project that have failed.
+
+    Args:
+        project_name: target project
+        result_file_type: the type of the result file
+    """
+    failed_revisions = []
+
+    result_files = __get_result_files_dict(project_name, result_file_type)
+    for _, value in result_files.items():
+        newest_res_file = max(value, key=lambda x: Path(x).stat().st_mtime)
+        match = result_file_type.FILE_NAME_FAILED_REGEX.search(newest_res_file.name)
+        if match:
+            failed_revisions.append(match.group("file_commit_hash"))
+
+    return failed_revisions

--- a/varats/data/revisions.py
+++ b/varats/data/revisions.py
@@ -25,9 +25,9 @@ def __get_result_files_dict(project_name: str, result_file_type) -> Dict:
         for res_file in res_dir.iterdir():
             if not str(res_file.stem).startswith("{}-".format(project_name)):
                 continue
-            match = result_file_type.FILE_NAME_REGEX.search(res_file.name)
-            if match:
-                result_files[match.group("file_commit_hash")].append(res_file)
+            if result_file_type.is_result_file(res_file.name):
+                commit_hash = result_file_type.get_commit_hash_from_result_file(res_file.name)
+                result_files[commit_hash].append(res_file)
 
     return result_files
 
@@ -47,8 +47,8 @@ def get_proccessed_revisions(project_name: str, result_file_type) -> [str]:
     for _, value in result_files.items():
         newest_res_file = max(value, key=lambda x: Path(x).stat().st_mtime)
         if result_file_type.is_result_file_success(newest_res_file.name):
-            match = result_file_type.FILE_NAME_REGEX.search(newest_res_file.name)
-            processed_revisions.append(match.group("file_commit_hash"))
+            commit_hash = result_file_type.get_commit_hash_from_result_file(newest_res_file.name)
+            processed_revisions.append(commit_hash)
 
     return processed_revisions
 
@@ -67,7 +67,7 @@ def get_failed_revisions(project_name: str, result_file_type) -> [str]:
     for _, value in result_files.items():
         newest_res_file = max(value, key=lambda x: Path(x).stat().st_mtime)
         if result_file_type.is_result_file_failed(newest_res_file.name):
-            match = result_file_type.FILE_NAME_REGEX.search(newest_res_file.name)
-            failed_revisions.append(match.group("file_commit_hash"))
+            commit_hash = result_file_type.get_commit_hash_from_result_file(newest_res_file.name)
+            failed_revisions.append(commit_hash)
 
     return failed_revisions

--- a/varats/data/revisions.py
+++ b/varats/data/revisions.py
@@ -25,7 +25,7 @@ def __get_result_files_dict(project_name: str, result_file_type) -> Dict:
         for res_file in res_dir.iterdir():
             if not str(res_file.stem).startswith("{}-".format(project_name)):
                 continue
-            match = result_file_type.FILE_STEM_REGEX.search(res_file.stem)
+            match = result_file_type.FILE_NAME_REGEX.search(res_file.name)
             if match:
                 result_files[match.group("file_commit_hash")].append(res_file)
 
@@ -46,8 +46,8 @@ def get_proccessed_revisions(project_name: str, result_file_type) -> [str]:
     result_files = __get_result_files_dict(project_name, result_file_type)
     for _, value in result_files.items():
         newest_res_file = max(value, key=lambda x: Path(x).stat().st_mtime)
-        match = result_file_type.FILE_NAME_SUCCESS_REGEX.search(newest_res_file.name)
-        if match:
+        if result_file_type.is_result_file_success(newest_res_file.name):
+            match = result_file_type.FILE_NAME_REGEX.search(newest_res_file.name)
             processed_revisions.append(match.group("file_commit_hash"))
 
     return processed_revisions
@@ -66,8 +66,8 @@ def get_failed_revisions(project_name: str, result_file_type) -> [str]:
     result_files = __get_result_files_dict(project_name, result_file_type)
     for _, value in result_files.items():
         newest_res_file = max(value, key=lambda x: Path(x).stat().st_mtime)
-        match = result_file_type.FILE_NAME_FAILED_REGEX.search(newest_res_file.name)
-        if match:
+        if result_file_type.is_result_file_failed(newest_res_file.name):
+            match = result_file_type.FILE_NAME_REGEX.search(newest_res_file.name)
             failed_revisions.append(match.group("file_commit_hash"))
 
     return failed_revisions

--- a/varats/experiments/GitBlameAnnotationReport.py
+++ b/varats/experiments/GitBlameAnnotationReport.py
@@ -34,10 +34,8 @@ class CFRAnalysis(actions.Step):
     DESCRIPTION = "Analyses the bitcode with CFR of VaRA."
 
     RESULT_FOLDER_TEMPLATE = "{result_dir}/{project_dir}"
-    RESULT_FILE_SUCCESS_TEMPLATE = \
-        "{project_name}-{binary_name}-{project_version}_{project_uuid}.yaml"
-    RESULT_FILE_FAILED_TEMPLATE = \
-        "{project_name}-{binary_name}-{project_version}_{project_uuid}.failed"
+    RESULT_FILE_TEMPLATE = \
+        "{project_name}-{binary_name}-{project_version}_{project_uuid}.{ext}"
 
     def __call__(self):
         """
@@ -64,17 +62,19 @@ class CFRAnalysis(actions.Step):
         mkdir("-p", vara_result_folder)
 
         for binary_name in project.BIN_NAMES:
-            result_file = self.RESULT_FILE_SUCCESS_TEMPLATE.format(
+            result_file = self.RESULT_FILE_TEMPLATE.format(
                 project_name=str(project.name),
                 binary_name=binary_name,
                 project_version=str(project.version),
-                project_uuid=str(project.run_uuid))
+                project_uuid=str(project.run_uuid),
+                ext="yaml")
 
-            result_error_file = self.RESULT_FILE_FAILED_TEMPLATE.format(
+            result_error_file = self.RESULT_FILE_TEMPLATE.format(
                 project_name=str(project.name),
                 binary_name=binary_name,
                 project_version=str(project.version),
-                project_uuid=str(project.run_uuid))
+                project_uuid=str(project.run_uuid),
+                ext="failed")
 
             run_cmd = opt[
                 "-vara-BD", "-vara-CFR",

--- a/varats/paper/case_study.py
+++ b/varats/paper/case_study.py
@@ -12,7 +12,7 @@ import yaml
 from numpy import random
 from scipy.stats import halfnorm
 
-from varats.data.revisions import get_proccessed_revisions
+from varats.data.revisions import get_proccessed_revisions, get_failed_revisions
 from varats.plots.plot_utils import check_required_args
 
 
@@ -232,14 +232,28 @@ class CaseStudy(yaml.YAMLObject):
             if rev[:10] in total_processed_revisions
         ]
 
+    def failed_revisions(self, result_file_type) -> [str]:
+        """
+        Calculate which revisions failed.
+        """
+        total_failed_revisions = set(
+            get_failed_revisions(self.project_name, result_file_type))
+
+        return [
+            rev for rev in self.revisions
+            if rev[:10] in total_failed_revisions
+        ]
+
     def get_revisions_status(self, result_file_type,
                              stage_num=-1) -> [(str, str)]:
         """
         Get status of all revisions.
         """
         processed_revisions = self.processed_revisions(result_file_type)
+        failed_revisions = self.failed_revisions(result_file_type)
         revisions_status = [(rev[:10],
-                             "OK" if rev in processed_revisions else "Missing")
+                             "OK" if rev in processed_revisions
+                             else "Failed" if rev in failed_revisions else "Missing")
                             for rev in self.revisions]
         if stage_num == -1:
             return revisions_status

--- a/varats/paper/paper_config_manager.py
+++ b/varats/paper/paper_config_manager.py
@@ -97,8 +97,12 @@ def get_status(case_study, result_file_type, sep_stages: bool,
 
     def color_rev_state(rev_state):
         if use_color:
-            return colors.green[
-                rev_state] if rev_state == "OK" else colors.red[rev_state]
+            if rev_state == "OK":
+                return colors.green[rev_state]
+            if rev_state == "Failed":
+                return colors.red[rev_state]
+            return colors.orange3[rev_state]
+
         return rev_state
 
     if sep_stages:

--- a/varats/plots/commit_interactions.py
+++ b/varats/plots/commit_interactions.py
@@ -39,7 +39,7 @@ def _build_interaction_table(report_files: [str], commit_map: CommitMap,
         ])
 
     def report_in_data_frame(report_file, df_col) -> bool:
-        match = CommitReport.FILE_STEM_REGEX.search(Path(report_file).name)
+        match = CommitReport.FILE_NAME_REGEX.search(Path(report_file).name)
         return (match.group("file_commit_hash") == df_col).any()
 
     missing_report_files = [
@@ -112,8 +112,7 @@ def _gen_interaction_graph(**kwargs) -> pd.DataFrame:
     reports = []
     for file_path in result_dir.iterdir():
         if file_path.stem.startswith(str(project_name) + "-"):
-            match = CommitReport.FILE_NAME_SUCCESS_REGEX.search(Path(file_path).name)
-            if match:
+            if CommitReport.is_result_file_success(Path(file_path).name):
                 reports.append(file_path)
 
     data_frame = _build_interaction_table(reports, commit_map,

--- a/varats/plots/commit_interactions.py
+++ b/varats/plots/commit_interactions.py
@@ -39,8 +39,8 @@ def _build_interaction_table(report_files: [str], commit_map: CommitMap,
         ])
 
     def report_in_data_frame(report_file, df_col) -> bool:
-        match = CommitReport.FILE_NAME_REGEX.search(Path(report_file).name)
-        return (match.group("file_commit_hash") == df_col).any()
+        commit_hash = CommitReport.get_commit_hash_from_result_file(Path(report_file).name)
+        return (commit_hash == df_col).any()
 
     missing_report_files = [
         report_file for report_file in report_files

--- a/varats/plots/commit_interactions.py
+++ b/varats/plots/commit_interactions.py
@@ -39,7 +39,7 @@ def _build_interaction_table(report_files: [str], commit_map: CommitMap,
         ])
 
     def report_in_data_frame(report_file, df_col) -> bool:
-        match = CommitReport.FILE_NAME_REGEX.search(Path(report_file).name)
+        match = CommitReport.FILE_STEM_REGEX.search(Path(report_file).name)
         return (match.group("file_commit_hash") == df_col).any()
 
     missing_report_files = [
@@ -112,7 +112,9 @@ def _gen_interaction_graph(**kwargs) -> pd.DataFrame:
     reports = []
     for file_path in result_dir.iterdir():
         if file_path.stem.startswith(str(project_name) + "-"):
-            reports.append(file_path)
+            match = CommitReport.FILE_NAME_SUCCESS_REGEX.search(Path(file_path).name)
+            if match:
+                reports.append(file_path)
 
     data_frame = _build_interaction_table(reports, commit_map,
                                           str(project_name))

--- a/varats/plots/commit_interactions.py
+++ b/varats/plots/commit_interactions.py
@@ -14,6 +14,7 @@ from varats.data.cache_helper import load_cached_df_or_none, cache_dataframe,\
 from varats.data.commit_report import CommitMap, CommitReport
 from varats.jupyterhelper.file import load_commit_report
 from varats.plots.plot_utils import check_required_args
+from varats.data.revisions import get_proccessed_revisions
 
 
 def _build_interaction_table(report_files: [str], commit_map: CommitMap,
@@ -106,11 +107,15 @@ def _gen_interaction_graph(**kwargs) -> pd.DataFrame:
     result_dir = Path(kwargs["result_folder"])
     project_name = kwargs["project"]
 
+    processed_revisions = get_proccessed_revisions(project_name, CommitReport)
+
     reports = []
     for file_path in result_dir.iterdir():
         if file_path.stem.startswith(str(project_name) + "-"):
             if CommitReport.is_result_file_success(Path(file_path).name):
-                reports.append(file_path)
+                commit_hash = CommitReport.get_commit_hash_from_result_file(Path(file_path).name)
+                if commit_hash in processed_revisions:
+                    reports.append(file_path)
 
     data_frame = _build_interaction_table(reports, commit_map,
                                           str(project_name))


### PR DESCRIPTION
A `*.failed` file is created in the results directory if the
analysis of the project fails.
Currently, the "failed" file is only created if the opt command
fails. If the analysis fails at an earlier stage, the failed file
is not created.

The `vara-cs status` command interprets this file if present, and shows the analysed revision
as failure. If no yaml report and no failure file is present it prints "missing".