### PR TITLE
Add support for named stages 

### DIFF
--- a/tests/paper/test_case_study.py
+++ b/tests/paper/test_case_study.py
@@ -11,6 +11,7 @@ YAML_CASE_STUDY = """!CaseStudy
 _CaseStudy__project_name: gzip
 _CaseStudy__stages:
 - !CSStage
+  _CSStage__name: stage_0
   _CSStage__revisions:
   - !HashIDTuple
     _HashIDTuple__commit_hash: 7620b817357d6f14356afd004ace2da426cf8c36
@@ -43,6 +44,7 @@ _CaseStudy__stages:
     _HashIDTuple__commit_hash: b8b25e7f1593f6dcc20660ff9fb1ed59ede15b7a
     _HashIDTuple__commit_id: 41
 - !CSStage
+  _CSStage__name: null
   _CSStage__revisions:
   - !HashIDTuple
     _HashIDTuple__commit_hash: 7620b817357d6f14356afd004ace2da426cf8c36
@@ -74,6 +76,13 @@ class TestCaseStudy(unittest.TestCase):
         Check if all revisions were loaded correctly.
         """
         self.assertEqual(len(self.case_study.revisions), 10)
+
+    def test_stage_name(self):
+        """
+        Check if the name of the stage is loaded correctly.
+        """
+        self.assertEqual(self.case_study.stages[0].name, "stage_0")
+        self.assertEqual(self.case_study.stages[1].name, None)
 
     def test_version(self):
         """

--- a/tests/paper/test_paper_config_manager.py
+++ b/tests/paper/test_paper_config_manager.py
@@ -122,7 +122,7 @@ class TestPaperConfigManager(unittest.TestCase):
         status = PCM.get_status(self.case_study, CommitReport, 5, True)
         self.assertEqual(
             status, """CS: gzip_1: (  0/10) processed [0/10/0]
-  Stage 0
+  Stage 0 (stage_0)
     7620b81735 [Missing]
     622e9b1d02 [Missing]
     8798d5c4fd [Missing]
@@ -145,7 +145,7 @@ class TestPaperConfigManager(unittest.TestCase):
         status = PCM.get_status(self.case_study, CommitReport, 5, True)
         self.assertEqual(
             status, """CS: gzip_1: (  2/10) processed [0/8/2]
-  Stage 0
+  Stage 0 (stage_0)
     7620b81735 [Missing]
     622e9b1d02 [Missing]
     8798d5c4fd [Missing]

--- a/varats/driver.py
+++ b/varats/driver.py
@@ -416,6 +416,13 @@ def main_casestudy() -> None:
             default=0,
             help="Add this many revisions per year to the case-study.")
         sub_parser.add_argument(
+            "--revs-year-sep",
+            action="store_true",
+            default=False,
+            help=
+            "Separate the revisions in different stages per year (when using \'--revs-per-year\')."
+        )
+        sub_parser.add_argument(
             "--num-rev",
             type=int,
             default=10,

--- a/varats/paper/case_study.py
+++ b/varats/paper/case_study.py
@@ -236,11 +236,14 @@ class CaseStudy(yaml.YAMLObject):
             for _ in range(abs(offset)):
                 self.__stages.pop(remove_index)
 
-    def insert_empty_stage(self, pos: int) -> None:
+    def insert_empty_stage(self, pos: int) -> CSStage:
         """
         Insert a new stage at the given index, shifting the list elements to the right.
+        The newly created stage is returned.
         """
-        self.__stages.insert(pos, CSStage())
+        new_stage = CSStage()
+        self.__stages.insert(pos, new_stage)
+        return new_stage
 
     def include_revision(self,
                          revision: str,

--- a/varats/paper/case_study.py
+++ b/varats/paper/case_study.py
@@ -222,8 +222,10 @@ class CaseStudy(yaml.YAMLObject):
         Shift a stage in the case-studie's stage list by an offset.
         Beware that shifts to the left (offset<0) will destroy stages.
         """
-        assert 0 <= from_index < len(self.__stages)
-        assert from_index + offset >= 0, "Shifting out of bounds"
+        if not (0 <= from_index < len(self.__stages)):
+            raise AssertionError("from_index out of bounds")
+        if (from_index + offset) < 0:
+            raise AssertionError("Shifting out of bounds")
 
         if offset > 0:
             for _ in range(offset):

--- a/varats/paper/case_study.py
+++ b/varats/paper/case_study.py
@@ -71,8 +71,9 @@ class CSStage(yaml.YAMLObject):
     yaml_loader = yaml.SafeLoader
     yaml_tag = u'!CSStage'
 
-    def __init__(self) -> None:
+    def __init__(self, name: tp.Optional[str] = None) -> None:
         self.__revisions: tp.List[HashIDTuple] = []
+        self.__name: tp.Optional[str] = name
 
     @property
     def revisions(self) -> tp.List[str]:
@@ -80,6 +81,20 @@ class CSStage(yaml.YAMLObject):
         Project revisions that are part of this case study.
         """
         return [x.commit_hash for x in self.__revisions]
+
+    @property
+    def name(self) -> tp.Optional[str]:
+        """
+        Name of the stage.
+        """
+        return self.__name
+
+    @name.setter
+    def name(self, name: str) -> None:
+        """
+        Setter for the name of the stage.
+        """
+        self.__name = name
 
     def has_revision(self, revision: str) -> bool:
         """
@@ -207,8 +222,8 @@ class CaseStudy(yaml.YAMLObject):
         Add multiple revisions to this case study.
 
         Args:
-            stage: The stage to insert the revisions
-            revisions: List of triples with (commit_hash, id) to be inserted
+            revisions: List of tuples with (commit_hash, id) to be inserted
+            stage_num: The stage to insert the revisions
             sort_revs: True if the stage should be kept sorted
         """
         for revision in revisions:
@@ -216,6 +231,17 @@ class CaseStudy(yaml.YAMLObject):
 
         if sort_revs and self.num_stages > 0:
             self.__stages[stage_num].sort()
+
+    def name_stage(self, stage_num: int, name: str) -> None:
+        """
+        Names an already existing stage.
+
+        Args:
+            stage_num: The number of the stage to name
+            name: The new name of the stage
+        """
+        if stage_num < self.num_stages:
+            self.__stages[stage_num].name = name
 
     def get_revision_filter(self) -> tp.Callable[[str], bool]:
         """
@@ -461,7 +487,7 @@ def extend_with_extra_revs(case_study: CaseStudy, cmap: CommitMap,
     case_study.include_revisions(new_rev_items, merge_stage, True)
 
 
-@check_required_args(['git_path', 'revs_per_year', 'merge_stage'])
+@check_required_args(['git_path', 'revs_per_year', 'merge_stage', 'revs_year_sep'])
 def extend_with_revs_per_year(case_study: CaseStudy, cmap: CommitMap,
                               **kwargs: tp.Any) -> None:
     """
@@ -470,6 +496,7 @@ def extend_with_revs_per_year(case_study: CaseStudy, cmap: CommitMap,
     repo_path = pygit2.discover_repository(kwargs['git_path'])
     repo = pygit2.Repository(repo_path)
     last_commit = repo[repo.head.target]
+    revs_year_sep = kwargs['revs_year_sep']
 
     commits: tp.DefaultDict[int, tp.List[str]] = defaultdict(
         list)  # maps year -> list of commits
@@ -478,7 +505,8 @@ def extend_with_revs_per_year(case_study: CaseStudy, cmap: CommitMap,
         commits[commit_date.year].append(str(commit.id))
 
     new_rev_items = []  # new revisions that get added to to case_study
-    for _, commits_in_year in commits.items():
+    num_stage: int = 0
+    for year, commits_in_year in commits.items():
         samples = min(len(commits_in_year), kwargs['revs_per_year'])
         sample_commit_indices = sorted(
             random.sample(range(len(commits_in_year)), samples))
@@ -488,7 +516,14 @@ def extend_with_revs_per_year(case_study: CaseStudy, cmap: CommitMap,
             time_id = cmap.time_id(commit_hash)
             new_rev_items.append((commit_hash, time_id))
 
-    case_study.include_revisions(new_rev_items, kwargs['merge_stage'], True)
+        case_study.include_revisions(
+            new_rev_items,
+            num_stage if revs_year_sep else kwargs['merge_stage'], False)
+        if revs_year_sep:
+            case_study.name_stage(num_stage, str(year))
+
+        num_stage += 1
+        new_rev_items.clear()
 
 
 @check_required_args(['distribution', 'merge_stage', 'num_rev'])

--- a/varats/paper/case_study.py
+++ b/varats/paper/case_study.py
@@ -596,7 +596,7 @@ def extend_with_revs_per_year(case_study: CaseStudy, cmap: CommitMap,
         else:
             stage_index = kwargs['merge_stage']
 
-        case_study.include_revisions(new_rev_items, stage_index, False)
+        case_study.include_revisions(new_rev_items, stage_index, True)
         new_rev_items.clear()
 
 

--- a/varats/paper/case_study.py
+++ b/varats/paper/case_study.py
@@ -234,7 +234,7 @@ class CaseStudy(yaml.YAMLObject):
             for _ in range(abs(offset)):
                 self.__stages.pop(remove_index)
 
-    def insert_empty_stage(self, pos) -> None:
+    def insert_empty_stage(self, pos: int) -> None:
         """
         Insert a new stage at the given index, shifting the list elements to the right.
         """

--- a/varats/paper/paper_config_manager.py
+++ b/varats/paper/paper_config_manager.py
@@ -139,8 +139,13 @@ def get_status(case_study: CaseStudy,
         return rev_state
 
     if sep_stages:
+        stages = case_study.stages
         for stage_num in range(0, case_study.num_stages):
-            status += "  Stage {idx}\n".format(idx=stage_num)
+            status += "  Stage {idx}".format(idx=stage_num)
+            stage_name = stages[stage_num].name
+            if stage_name:
+                status += " ({})".format(stage_name)
+            status += "\n"
             for rev_state in case_study.get_revisions_status(
                     result_file_type, stage_num):
                 status += "    {rev} [{status}]\n".format(


### PR DESCRIPTION
resolves se-passau/VaRA#433

They can already be used with the 'per_year_add'
extension stragegy by using the '--revs_year_sep'
parameter.

To update the case-study files to the new format, the following command can be used:
```
find . -name "*.case_study" -exec sed -i '/^- !CSStage/a \ \ _CSStage__name: null' {} \;
```