### PR TITLE
Set error file extension to .txt

### DIFF
--- a/tests/data/test_commit_report.py
+++ b/tests/data/test_commit_report.py
@@ -237,7 +237,7 @@ class TestCommitReport(unittest.TestCase):
                                 "success.yaml")
         cls.fail_filename = ("CR-foo-foo-7bb9ef5f8c_"
                              "fdb09c5a-4cee-42d8-bbdc-4afe7a7864be"
-                             "_failed.yaml")
+                             "_failed.txt")
 
     def test_path(self):
         """
@@ -303,7 +303,7 @@ class TestCommitReport(unittest.TestCase):
         self.assertEqual(
             CommitReport.get_file_name("foo", "foo", "7bb9ef5f8c",
                                        "fdb09c5a-4cee-42d8-bbdc-4afe7a7864be",
-                                       FileStatusExtension.Failed),
+                                       FileStatusExtension.Failed, '.txt'),
             self.fail_filename)
 
 

--- a/tests/data/test_report.py
+++ b/tests/data/test_report.py
@@ -19,9 +19,11 @@ class TestMetaReport(unittest.TestCase):
         Setup file and CommitReport
         """
         cls.success_filename = ("EMPTY-foo-foo-7bb9ef5f8c_"
-                                "fdb09c5a-4cee-42d8-bbdc-4afe7a7864be_success")
+                                "fdb09c5a-4cee-42d8-bbdc-4afe7a7864be_"
+                                "success.txt")
         cls.fail_filename = ("EMPTY-foo-foo-7bb9ef5f8c_"
-                             "fdb09c5a-4cee-42d8-bbdc-4afe7a7864be_failed")
+                             "fdb09c5a-4cee-42d8-bbdc-4afe7a7864be_"
+                             "failed.txt")
 
     def test_is_result_file(self):
         """Check if the result file matcher works"""

--- a/varats/data/report.py
+++ b/varats/data/report.py
@@ -183,7 +183,7 @@ class MetaReport(type):
                       project_version: str,
                       project_uuid: str,
                       extension_type: FileStatusExtension,
-                      file_ext: str = "") -> str:
+                      file_ext: str = ".txt") -> str:
         """
         Generates a filename for a commit report
         """

--- a/varats/data/reports/commit_report.py
+++ b/varats/data/reports/commit_report.py
@@ -171,7 +171,8 @@ class CommitReport(BaseReport):
     @staticmethod
     def get_file_name(project_name: str, binary_name: str,
                       project_version: str, project_uuid: str,
-                      extension_type: FileStatusExtension) -> str:
+                      extension_type: FileStatusExtension,
+                      file_ext: str = "yaml") -> str:
         """
         Generates a filename for a commit report with 'yaml'
         as file extension.
@@ -179,11 +180,11 @@ class CommitReport(BaseReport):
         return BaseReport.get_file_name(CommitReport.SHORTHAND, project_name,
                                         binary_name, project_version,
                                         project_uuid, extension_type,
-                                        CommitReport.FILE_TYPE)
+                                        file_ext)
 
     def calc_max_cf_edges(self) -> int:
         """
-        Calulate the highest amount of control-flow interactions of a single
+        Calculate the highest amount of control-flow interactions of a single
         commit region.
         """
         cf_map: tp.Dict[str, tp.List[int]] = dict()
@@ -197,7 +198,7 @@ class CommitReport(BaseReport):
 
     def calc_max_df_edges(self) -> int:
         """
-        Calulate the highest amount of data-flow interactions of a single
+        Calculate the highest amount of data-flow interactions of a single
         commit region.
         """
         df_map: tp.Dict[str, tp.List[int]] = dict()
@@ -419,8 +420,8 @@ def generate_inout_cfg_cf(commit_report: CommitReport,
         rows.append([item[0], item[1][1], "To", total])
 
     rows.sort(
-        key=
-        lambda row: (row[0], -tp.cast(int, row[3]), -tp.cast(int, row[1]), row[2])
+        key=lambda row: (row[0], -tp.cast(int, row[3]), -
+                         tp.cast(int, row[1]), row[2])
     )
 
     return pd.DataFrame(
@@ -472,8 +473,8 @@ def generate_inout_cfg_df(commit_report: CommitReport,
         rows.append([item[0], item[1][1], "To", total])
 
     rows.sort(
-        key=
-        lambda row: (row[0], -tp.cast(int, row[3]), -tp.cast(int, row[1]), row[2])
+        key=lambda row: (row[0], -tp.cast(int, row[3]), -
+                         tp.cast(int, row[1]), row[2])
     )
 
     return pd.DataFrame(

--- a/varats/data/reports/empty_report.py
+++ b/varats/data/reports/empty_report.py
@@ -16,10 +16,12 @@ class EmptyReport(BaseReport):
     @staticmethod
     def get_file_name(project_name: str, binary_name: str,
                       project_version: str, project_uuid: str,
-                      extension_type: FileStatusExtension) -> str:
+                      extension_type: FileStatusExtension,
+                      file_ext=".txt") -> str:
         """
         Generates a filename for a commit report without any file ending.
         """
         return BaseReport.get_file_name(EmptyReport.SHORTHAND, project_name,
                                         binary_name, project_version,
-                                        project_uuid, extension_type)
+                                        project_uuid, extension_type,
+                                        file_ext)

--- a/varats/data/reports/empty_report.py
+++ b/varats/data/reports/empty_report.py
@@ -17,7 +17,7 @@ class EmptyReport(BaseReport):
     def get_file_name(project_name: str, binary_name: str,
                       project_version: str, project_uuid: str,
                       extension_type: FileStatusExtension,
-                      file_ext=".txt") -> str:
+                      file_ext: str = ".txt") -> str:
         """
         Generates a filename for a commit report without any file ending.
         """

--- a/varats/experiments/git_blame_annotation_report.py
+++ b/varats/experiments/git_blame_annotation_report.py
@@ -100,7 +100,8 @@ class CFRAnalysis(actions.Step):  # type: ignore
                         binary_name=binary_name,
                         project_version=str(project.version),
                         project_uuid=str(project.run_uuid),
-                        extension_type=FSE.Failed), run_cmd, timeout_duration))
+                        extension_type=FSE.Failed,
+                        file_ext=".txt"), run_cmd, timeout_duration))
 
 
 class GitBlameAnntotationReport(VaRAVersionExperiment):
@@ -138,7 +139,8 @@ class GitBlameAnntotationReport(VaRAVersionExperiment):
                     binary_name="all",
                     project_version=str(project.version),
                     project_uuid=str(project.run_uuid),
-                    extension_type=FSE.CompileError),
+                    extension_type=FSE.CompileError,
+                    file_ext=".txt"),
             ))
 
         # This c-flag is provided by VaRA and it suggests to use the git-blame
@@ -147,7 +149,7 @@ class GitBlameAnntotationReport(VaRAVersionExperiment):
 
         analysis_actions = []
 
-        # Check if all binaries have correspondong BC files
+        # Check if all binaries have corresponding BC files
         all_files_present = True
         for binary_name in project.BIN_NAMES:
             all_files_present &= path.exists(


### PR DESCRIPTION
Each experiment can define own file types for its compile errors, failed runs and successful runs.
The commit_reports still used .yaml for all of them, but now only uses .yaml for successful runs and .txt otherwise.