### PR TITLE
Revert to matplotlib 3.1.0 until 3.1.2 is released

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
         "PyQt5>=5.10.0",
         "PyYAML>=3.12",
         "seaborn>=0.8.0",
-        "matplotlib>=2.2.0",
+        "matplotlib==3.1.0",
         "pandas>=0.22.0",
         "benchbuild>=4.0.1",
         "plumbum>=1.6.6",


### PR DESCRIPTION
The current matplotlib version 3.1.1 breaks seaborn heatmaps.
Matplotlib 3.1.2 will fix this issue, but it is not released yet.
Once it is released, the setup.py entry should be changed to
"matplotlib>=3.1.2".