### PR TITLE
Add interaction filter support to GitBlameAnnotationReport experiment

### DIFF
--- a/varats/experiments/git_blame_annotation_report.py
+++ b/varats/experiments/git_blame_annotation_report.py
@@ -112,7 +112,7 @@ class CFRAnalysis(actions.Step):  # type: ignore
                                   binary_name=binary_name,
                                   project_version=project.version))
 
-            run_cmd = opt.__getitem__(opt_params)
+            run_cmd = opt(*opt_params)
 
             timeout_duration = '8h'
             from benchbuild.utils.cmd import timeout

--- a/varats/experiments/git_blame_annotation_report.py
+++ b/varats/experiments/git_blame_annotation_report.py
@@ -45,7 +45,9 @@ class CFRAnalysis(actions.Step):  # type: ignore
 
     INTERACTION_FILTER_TEMPLATE = "InteractionFilter-{experiment}-{project}.yaml"
 
-    def __init__(self, project: Project, interaction_filter_experiment_name: str = None):
+    def __init__(self,
+                 project: Project,
+                 interaction_filter_experiment_name: tp.Optional[str] = None):
         super(CFRAnalysis, self).__init__(obj=project, action_fn=self.analyze)
         self.__interaction_filter_experiment_name = interaction_filter_experiment_name
 


### PR DESCRIPTION
By default, the GitBlameAnnotationReport experiment looks for an interaction filter file
named `InteractionFilter-GitBlameAnnotationReport-{project_name}.yaml`.

The used file name can be further customized by subclassing the experiment.
Instead of the string "GitBlameAnnotationReport", the user can use a different string
by calling the experiment's superclass constructor with the appropriate string.