### PR TITLE
Add support for supplementary result files

### DIFF
--- a/tests/data/test_report.py
+++ b/tests/data/test_report.py
@@ -12,7 +12,6 @@ class TestMetaReport(unittest.TestCase):
     """
     Test basic CommitReport functionality.
     """
-
     @classmethod
     def setUpClass(cls):
         """
@@ -22,9 +21,11 @@ class TestMetaReport(unittest.TestCase):
                                 "fdb09c5a-4cee-42d8-bbdc-4afe7a7864be_"
                                 "success.txt")
         cls.fail_filename = ("EMPTY-foo-foo-7bb9ef5f8c_"
-                             "fdb09c5a-4cee-42d8-bbdc-4afe7a7864be_failed.txt")
-        cls.supplementary_filename = ("CR-SUPPL-foo-foo-7bb9ef5f8c_"
-                                "fdb09c5a-4cee-42d8-bbdc-4afe7a7864be_test.txt")
+                             "fdb09c5a-4cee-42d8-bbdc-4afe7a7864be_"
+                             "failed.txt")
+        cls.supplementary_filename = (
+            "CR-SUPPL-foo-foo-7bb9ef5f8c_"
+            "fdb09c5a-4cee-42d8-bbdc-4afe7a7864be_test.txt")
 
     def test_is_result_file(self):
         """Check if the result file matcher works"""

--- a/tests/data/test_report.py
+++ b/tests/data/test_report.py
@@ -6,6 +6,7 @@ import unittest
 
 from varats.data.report import FileStatusExtension, MetaReport
 from varats.data.reports.empty_report import EmptyReport
+from varats.data.reports.commit_report import CommitReport as CR
 
 
 class TestMetaReport(unittest.TestCase):

--- a/tests/data/test_report.py
+++ b/tests/data/test_report.py
@@ -6,6 +6,7 @@ import unittest
 
 from varats.data.report import FileStatusExtension, MetaReport
 from varats.data.reports.empty_report import EmptyReport
+from varats.data.reports.commit_report import CommitReport as CR
 
 
 class TestMetaReport(unittest.TestCase):
@@ -22,6 +23,8 @@ class TestMetaReport(unittest.TestCase):
                                 "fdb09c5a-4cee-42d8-bbdc-4afe7a7864be_success")
         cls.fail_filename = ("EMPTY-foo-foo-7bb9ef5f8c_"
                              "fdb09c5a-4cee-42d8-bbdc-4afe7a7864be_failed")
+        cls.supplementary_filename = ("CR-SUPPL-foo-foo-7bb9ef5f8c_"
+                                "fdb09c5a-4cee-42d8-bbdc-4afe7a7864be_test.txt")
 
     def test_is_result_file(self):
         """Check if the result file matcher works"""
@@ -30,7 +33,18 @@ class TestMetaReport(unittest.TestCase):
         self.assertFalse(
             MetaReport.is_result_file(self.success_filename.replace("_", "")))
         self.assertFalse(
-            MetaReport.is_result_file(self.success_filename.replace("-", "")))
+            MetaReport.is_result_file(self.fail_filename.replace("-", "")))
+
+    def test_is_supplementary_result_file(self):
+        """Check if the supplementary result file matcher works"""
+        self.assertTrue(
+            MetaReport.is_result_file_supplementary(
+                self.supplementary_filename))
+        self.assertFalse(
+            MetaReport.is_result_file_supplementary(
+                self.supplementary_filename.replace("_", "")))
+        self.assertFalse(MetaReport.is_result_file(
+            self.supplementary_filename))
 
     def test_file_status(self):
         """
@@ -55,6 +69,22 @@ class TestMetaReport(unittest.TestCase):
             MetaReport.get_commit_hash_from_result_file(self.fail_filename),
             "7bb9ef5f8c")
 
+    def test_get_commit_supplementary(self):
+        """
+        Check if the correct commit hash is returned.
+        """
+        self.assertEqual(
+            MetaReport.get_commit_hash_from_supplementary_result_file(
+                self.supplementary_filename), "7bb9ef5f8c")
+
+    def test_get_info_type_supplementary(self):
+        """
+        Check if the correct info_type is returned.
+        """
+        self.assertEqual(
+            MetaReport.get_info_type_from_supplementary_result_file(
+                self.supplementary_filename), "test")
+
     def test_file_name_creation(self):
         """
          Check if file names are created correctly.
@@ -70,3 +100,13 @@ class TestMetaReport(unittest.TestCase):
                                       "fdb09c5a-4cee-42d8-bbdc-4afe7a7864be",
                                       FileStatusExtension.Failed),
             self.fail_filename)
+
+    def test_supplementary_file_name_creation(self):
+        """
+         Check if file names are created correctly.
+        """
+        self.assertEqual(
+            CR.get_supplementary_file_name(
+                "foo", "foo", "7bb9ef5f8c",
+                "fdb09c5a-4cee-42d8-bbdc-4afe7a7864be", "test", "txt"),
+            self.supplementary_filename)

--- a/varats/data/reports/commit_report.py
+++ b/varats/data/reports/commit_report.py
@@ -181,6 +181,17 @@ class CommitReport(BaseReport):
                                         project_uuid, extension_type,
                                         CommitReport.FILE_TYPE)
 
+    @staticmethod
+    def get_supplementary_file_name(project_name: str, binary_name: str,
+                                    project_version: str, project_uuid: str,
+                                    info_type: str, file_ext: str) -> str:
+        """
+        Generates a filename for a commit report supplementary file.
+        """
+        return BaseReport.get_supplementary_file_name(
+            CommitReport.SHORTHAND, project_name, binary_name, project_version,
+            project_uuid, info_type, file_ext)
+
     def calc_max_cf_edges(self) -> int:
         """
         Calulate the highest amount of control-flow interactions of a single

--- a/varats/data/revisions.py
+++ b/varats/data/revisions.py
@@ -154,6 +154,7 @@ def get_supplementary_result_files(project_name: str,
         project_name (str): target project
         result_file_type (MetaReport): the type of the result file
         revision (str): The revision for which the result files should be returned.
+        suppl_info_type (str): Only include result files of the specified type
 
     Returns:
         [(Path, str, str)]: List of tuples of result file path, revision,

--- a/varats/data/revisions.py
+++ b/varats/data/revisions.py
@@ -136,3 +136,36 @@ def get_tagged_revisions(project_name: str, result_file_type: MetaReport
                                   str(newest_res_file))))
 
     return revisions
+
+
+def get_supplementary_result_files(project_name: str,
+                                   result_file_type: MetaReport,
+                                   revision: tp.Optional[str] = None,
+                                   suppl_info_type: tp.Optional[str] = None
+                                   ) -> tp.List[tp.Tuple[Path, str, str]]:
+    """
+    Returns the current supplementary result files for a given project and
+    report type.
+    If a specific revision is specified then only the result files for the
+    passed revision are returned, otherwise all files for all available
+    revisions are returned.
+    Args:
+        project_name (str): target project
+        result_file_type (MetaReport): the type of the result file
+        revision (str): The revision for which the result files should be returned.
+        suppl_info_type (str): Only include result files of the specified type
+    Returns:
+        [(Path, str, str)]: List of tuples of result file path, revision,
+                            and supplementary result file type
+    """
+    result_files = __get_supplementary_result_files_dict(
+        project_name, result_file_type, revision)
+
+    result = []
+
+    for (commit_hash, info_type), file_list in result_files.items():
+        if (suppl_info_type is None) or (info_type == suppl_info_type):
+            newest_res_file = max(file_list, key=lambda x: x.stat().st_mtime)
+            result.append((newest_res_file, commit_hash, info_type))
+
+    return result

--- a/varats/data/revisions.py
+++ b/varats/data/revisions.py
@@ -35,6 +35,45 @@ def __get_result_files_dict(project_name: str, result_file_type: MetaReport
     return result_files
 
 
+def __get_supplementary_result_files_dict(
+        project_name: str,
+        result_file_type: MetaReport,
+        revision: tp.Optional[str] = None,
+) -> tp.Dict[tp.Tuple[str, str], tp.List[Path]]:
+    """
+    Returns a dict that maps the commit_hash and the info_type to a list
+    of all supplementary result files for that commit and info_type.
+    If an (optional) revision is specified the nonly result files for that
+    commit are returned.
+
+    Args:
+        project_name: target project
+        result_file_type: the type of the result file
+        revision (str): The revision for which the result files should be returned.
+
+    Returns:
+        Dict that maps (commit_hash, info_type) to list of result files
+    """
+    res_dir = Path("{result_folder}/{project_name}/".format(
+        result_folder=CFG["result_dir"], project_name=project_name))
+
+    result_files: tp.DefaultDict[
+        tp.Tuple[str, str], tp.List[Path]] = defaultdict(
+            list)  # maps (commit_hash, suppl._file_type) -> list of res files
+
+    if res_dir.exists():
+        for res_file in res_dir.iterdir():
+            if result_file_type.is_result_file_supplementary(res_file.name):
+                commit_hash = result_file_type.get_commit_hash_from_supplementary_result_file(
+                    res_file.name)
+                info_type = result_file_type.get_info_type_from_supplementary_result_file(
+                    res_file.name)
+                if revision is None or commit_hash == revision:
+                    result_files[(commit_hash, info_type)].append(res_file)
+
+    return result_files
+
+
 def get_proccessed_revisions(project_name: str,
                              result_file_type: MetaReport) -> tp.List[str]:
     """
@@ -97,3 +136,34 @@ def get_tagged_revisions(project_name: str, result_file_type: MetaReport
                                   str(newest_res_file))))
 
     return revisions
+
+
+def get_supplementary_result_files(project_name: str,
+                                   result_file_type: MetaReport,
+                                   revision: tp.Optional[str] = None
+                                   ) -> tp.List[tp.Tuple[Path, str, str]]:
+    """
+    Returns the current supplementary result files for a given project and
+    report type.
+    If a specific revision is specified then only the result files for the
+    passed revision are returned, otherwise all files for all available
+    revisions are returned.
+
+    Args:
+        project_name (str): target project
+        result_file_type (MetaReport): the type of the result file
+        revision (str): The revision for which the result files should be returned.
+
+    Returns:
+        (Path, str, str): Tuple of result file path, revision, and result file type
+    """
+    result_files = __get_supplementary_result_files_dict(
+        project_name, result_file_type, revision)
+
+    result = []
+
+    for (commit_hash, info_type), file_list in result_files.items():
+        newest_res_file = max(file_list, key=lambda x: x.stat().st_mtime)
+        result.append((newest_res_file, commit_hash, info_type))
+
+    return result

--- a/varats/data/revisions.py
+++ b/varats/data/revisions.py
@@ -140,7 +140,8 @@ def get_tagged_revisions(project_name: str, result_file_type: MetaReport
 
 def get_supplementary_result_files(project_name: str,
                                    result_file_type: MetaReport,
-                                   revision: tp.Optional[str] = None
+                                   revision: tp.Optional[str] = None,
+                                   suppl_info_type: tp.Optional[str] = None
                                    ) -> tp.List[tp.Tuple[Path, str, str]]:
     """
     Returns the current supplementary result files for a given project and
@@ -155,7 +156,8 @@ def get_supplementary_result_files(project_name: str,
         revision (str): The revision for which the result files should be returned.
 
     Returns:
-        (Path, str, str): Tuple of result file path, revision, and result file type
+        [(Path, str, str)]: List of tuples of result file path, revision,
+                            and supplementary result file type
     """
     result_files = __get_supplementary_result_files_dict(
         project_name, result_file_type, revision)
@@ -163,7 +165,8 @@ def get_supplementary_result_files(project_name: str,
     result = []
 
     for (commit_hash, info_type), file_list in result_files.items():
-        newest_res_file = max(file_list, key=lambda x: x.stat().st_mtime)
-        result.append((newest_res_file, commit_hash, info_type))
+        if (suppl_info_type is None) or (info_type == suppl_info_type):
+            newest_res_file = max(file_list, key=lambda x: x.stat().st_mtime)
+            result.append((newest_res_file, commit_hash, info_type))
 
     return result

--- a/varats/utils/experiment_util.py
+++ b/varats/utils/experiment_util.py
@@ -59,13 +59,22 @@ class PEErrorHandler():
                  result_folder: str,
                  error_file_name: str,
                  run_cmd: tp.Optional[BoundCommand] = None,
-                 timeout_duration: tp.Optional[str] = None):
+                 timeout_duration: tp.Optional[str] = None,
+                 delete_files: tp.Optional[tp.List[Path]] = None):
         self.__result_folder = result_folder
         self.__error_file_name = error_file_name
         self.__run_cmd = run_cmd
         self.__timeout_duration = timeout_duration
+        self.__delete_files = delete_files
 
     def __call__(self, ex: Exception) -> None:
+        if self.__delete_files is not None:
+            for delete_file in self.__delete_files:
+                try:
+                    delete_file.unlink()
+                except FileNotFoundError:
+                    pass
+
         error_file = Path("{res_folder}/{res_file}".format(
             res_folder=self.__result_folder, res_file=self.__error_file_name))
         if not os.path.exists(self.__result_folder):


### PR DESCRIPTION
This PR enables experiments to create supplementary
result files in addition to the main result file.

The `CommitReport.get_supplementary_file_name` method
can be used to generate a supplementary report file.
Multiple supplementary files per revision are also
possible.
They can be differentiated by the methods `info_type`
parameter.

The experiment can then use the generated filenames
to create these files and store additional information
or results of the experiment (e.g. the experiments duration
time).

Contrary to the "normal" result files, these supplementary
files do not indictate a success or failure of the experiment.
They are intended to provide additional information about
successful experiment runs.

This means that if an experiment fails, supplementary files
that have already been created should be deleted.
This can easily be done by the experiment by passing a
list of files to the experiments `PEErrorHandler`.

If the experiment fails and the error handler is called,
it will automatically delete all files of the passed list.