### PR TITLE
Adds missing dependency to libyaml-dev in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ For ubuntu, you can use the following command to install them (your system has t
 have at least `python3.6`):
 
 ```bash
-sudo apt install python3-dev python3-tk python3-psutil psutils ninja-build python3-pip autoconf cmake ruby curl time
+sudo apt install python3-dev python3-tk python3-psutil psutils ninja-build python3-pip autoconf cmake ruby curl time libyaml-dev
 sudo apt install python3-venv # If you want to install VaRA-TS in a python virtualenv
 ```
 


### PR DESCRIPTION
To use pyyaml's CLoader, the package `libyaml-dev` is needed on debian based systems according to https://github.com/yaml/pyyaml/issues/108.
This PR adds this package to the list of install dependencies for the tool suite.