### PR TITLE
Adds extender strategy to case study yaml files

### DIFF
--- a/varats/paper/case_study.py
+++ b/varats/paper/case_study.py
@@ -341,8 +341,11 @@ class CaseStudy():
         self.__stages.insert(pos, new_stage)
         return new_stage
 
-    def include_revision(self, revision: str, commit_id: int,
-                         stage_num: int = 0, sort_revs: bool = True) -> None:
+    def include_revision(self,
+                         revision: str,
+                         commit_id: int,
+                         stage_num: int = 0,
+                         sort_revs: bool = True) -> None:
         """
         Add a revision to this case study.
         """
@@ -357,14 +360,13 @@ class CaseStudy():
             if sort_revs:
                 stage.sort()
 
-    def include_revisions(self,
-                          revisions: tp.List[tp.Tuple[str, int]],
-                          stage_num: int = 0,
-                          sort_revs: bool = True,
-                          extender_strategy: tp.Optional[
-                              ExtenderStrategy] = None,
-                          sampling_method: tp.Optional[SamplingMethod] = None
-                          ) -> None:
+    def include_revisions(
+            self,
+            revisions: tp.List[tp.Tuple[str, int]],
+            stage_num: int = 0,
+            sort_revs: bool = True,
+            extender_strategy: tp.Optional[ExtenderStrategy] = None,
+            sampling_method: tp.Optional[SamplingMethod] = None) -> None:
         """
         Add multiple revisions to this case study.
 
@@ -387,10 +389,9 @@ class CaseStudy():
             # if different strategies are used on the same stage,
             # the result is 'mixed'.
             # Also if sampled multiple times with a distribution.
-            if (stage.extender_strategy is not None
-                and (stage.extender_strategy is not extender_strategy
-                     or stage.extender_strategy is ExtenderStrategy.distrib_add)
-            ):
+            if (stage.extender_strategy is not None and
+                (stage.extender_strategy is not extender_strategy
+                 or stage.extender_strategy is ExtenderStrategy.distrib_add)):
                 stage.extender_strategy = ExtenderStrategy.mixed
                 stage.sampling_method = None
             else:
@@ -513,12 +514,12 @@ def load_case_study_from_file(file_path: Path) -> CaseStudy:
                 extender_strategy = raw_stage.get('extender_strategy') or None
                 sampling_method = raw_stage.get('sampling_method') or None
                 stages.append(
-                    CSStage(raw_stage.get('name') or None,
-                            ExtenderStrategy[
-                                extender_strategy] if extender_strategy is not None else None,
-                            SamplingMethod[
-                                sampling_method] if sampling_method is not None else None,
-                            hash_id_tuples))
+                    CSStage(
+                        raw_stage.get('name') or None,
+                        ExtenderStrategy[extender_strategy]
+                        if extender_strategy is not None else None,
+                        SamplingMethod[sampling_method] if
+                        sampling_method is not None else None, hash_id_tuples))
 
             return CaseStudy(raw_case_study['project_name'],
                              raw_case_study['version'], stages)
@@ -749,8 +750,7 @@ def extend_with_distrib_sampling(case_study: CaseStudy, cmap: CommitMap,
         sample_n(distribution_function, kwargs['num_rev'], revision_list),
         kwargs['merge_stage'],
         extender_strategy=ExtenderStrategy.distrib_add,
-        sampling_method=kwargs['distribution']
-    )
+        sampling_method=kwargs['distribution'])
 
 
 def sample_n(distrib_func: tp.Callable[[int], np.ndarray], num_samples: int,
@@ -806,10 +806,10 @@ def extend_with_smooth_revs(case_study: CaseStudy, cmap: CommitMap,
     ]
     if new_revisions:
         print("Found new revisions: ", new_revisions)
-        case_study.include_revisions([(rev, cmap.time_id(rev))
-                                      for rev in new_revisions],
-                                     kwargs['merge_stage'],
-                                     extender_strategy=ExtenderStrategy.smooth_plot)
+        case_study.include_revisions(
+            [(rev, cmap.time_id(rev)) for rev in new_revisions],
+            kwargs['merge_stage'],
+            extender_strategy=ExtenderStrategy.smooth_plot)
     else:
         print("No new revisions found that where not already "
               "present in the case study.")

--- a/varats/paper/case_study.py
+++ b/varats/paper/case_study.py
@@ -30,6 +30,7 @@ class ExtenderStrategy(Enum):
     Enum for all currently supported extender strategies.
     """
 
+    mixed = -1
     simple_add = 1
     distrib_add = 2
     smooth_plot = 3
@@ -340,14 +341,8 @@ class CaseStudy():
         self.__stages.insert(pos, new_stage)
         return new_stage
 
-    def include_revision(self,
-                         revision: str,
-                         commit_id: int,
-                         stage_num: int = 0,
-                         sort_revs: bool = True,
-                         extender_strategy: tp.Optional[ExtenderStrategy] = None,
-                         sampling_method: tp.Optional[SamplingMethod] = None
-                         ) -> None:
+    def include_revision(self, revision: str, commit_id: int,
+                         stage_num: int = 0, sort_revs: bool = True) -> None:
         """
         Add a revision to this case study.
         """
@@ -362,16 +357,12 @@ class CaseStudy():
             if sort_revs:
                 stage.sort()
 
-        if extender_strategy is not None:
-            stage.extender_strategy = extender_strategy
-        if sampling_method is not None:
-            stage.sampling_method = sampling_method
-
     def include_revisions(self,
                           revisions: tp.List[tp.Tuple[str, int]],
                           stage_num: int = 0,
                           sort_revs: bool = True,
-                          extender_strategy: tp.Optional[ExtenderStrategy] = None,
+                          extender_strategy: tp.Optional[
+                              ExtenderStrategy] = None,
                           sampling_method: tp.Optional[SamplingMethod] = None
                           ) -> None:
         """
@@ -385,11 +376,21 @@ class CaseStudy():
             sampling_method: The sampling method used to acquire the revisions
         """
         for revision in revisions:
-            self.include_revision(revision[0], revision[1], stage_num, False,
-                                  extender_strategy, sampling_method)
+            self.include_revision(revision[0], revision[1], stage_num, False)
+
+        stage = self.__stages[stage_num]
 
         if sort_revs and self.num_stages > 0:
             self.__stages[stage_num].sort()
+
+        if extender_strategy is not None:
+            if stage.extender_strategy is not None:
+                stage.extender_strategy = ExtenderStrategy.mixed
+                stage.sampling_method = None
+            else:
+                stage.extender_strategy = extender_strategy
+                if sampling_method is not None:
+                    stage.sampling_method = sampling_method
 
     def name_stage(self, stage_num: int, name: str) -> None:
         """

--- a/varats/paper/case_study.py
+++ b/varats/paper/case_study.py
@@ -384,7 +384,13 @@ class CaseStudy():
             self.__stages[stage_num].sort()
 
         if extender_strategy is not None:
-            if stage.extender_strategy is not None:
+            # if different strategies are used on the same stage,
+            # the result is 'mixed'.
+            # Also if sampled multiple times with a distribution.
+            if (stage.extender_strategy is not None
+                and (stage.extender_strategy is not extender_strategy
+                     or stage.extender_strategy is ExtenderStrategy.distrib_add)
+            ):
                 stage.extender_strategy = ExtenderStrategy.mixed
                 stage.sampling_method = None
             else:


### PR DESCRIPTION
This PR adds the extender strategy and, if available, the sampling method that were used to create/extend each stage of a case study to the case study yaml file format.

If the same stage is extended multiple times with different strategies, the result is `mixed` as the revisions in the stage cannot be mapped to the different extender strategies any more.
Also, if the same stage is extended by the distribution sampler more than once, the result is always `mixed`, even if the same distribution was used. This is because the set union of two samples sampled from the same population with the same distribution does in general **not** result in a valid sample of that distribution.