### PR TITLE
Extends vara-develop all mode to remaining sub-commands

### DIFF
--- a/varats/development.py
+++ b/varats/development.py
@@ -133,25 +133,25 @@ def checkout_remote_branch_for_projects(
                   format(branch=fixed_branch_name, project=project.name))
 
 
-def pull_projects(projects: tp.List[LLVMProject]) -> None:
+def pull_projects(projects: tp.List[LLVMProjects]) -> None:
     """
     Pull the current branch of all projects.
     """
     llvm_folder = Path(str(CFG['llvm_source_dir']))
 
     for project in projects:
-        print("Pulling {project}".format(project=project.name))
+        print("Pulling {project}".format(project=project.project_name))
         pull_current_branch(llvm_folder / project.path)
 
 
-def push_projects(projects: tp.List[LLVMProject]) -> None:
+def push_projects(projects: tp.List[LLVMProjects]) -> None:
     """
     Push the current branch of all projects.
     """
     llvm_folder = Path(str(CFG['llvm_source_dir']))
 
     for project in projects:
-        print("Pushing {project}".format(project=project.name))
+        print("Pushing {project}".format(project=project.project_name))
 
         branch_name = get_current_branch(llvm_folder / project.path)
         if branch_has_upstream(llvm_folder / project.path, branch_name):
@@ -161,7 +161,7 @@ def push_projects(projects: tp.List[LLVMProject]) -> None:
                                 branch_name)
 
 
-def show_status_for_projects(projects: tp.List[LLVMProject]) -> None:
+def show_status_for_projects(projects: tp.List[LLVMProjects]) -> None:
     """
     Show the status of all projects.
     """
@@ -172,7 +172,7 @@ def show_status_for_projects(projects: tp.List[LLVMProject]) -> None:
         print("""
 {dlim}
 # Project: {name:67s} #
-{dlim}""".format(dlim=dlim, name=project.name))
+{dlim}""".format(dlim=dlim, name=project.project_name))
         show_status(llvm_folder / project.path)
 
 

--- a/varats/driver.py
+++ b/varats/driver.py
@@ -6,6 +6,7 @@ Main drivers for VaRA-TS
 import os
 import sys
 import argparse
+import typing as tp
 from pathlib import Path
 from argparse_utils import enum_action
 
@@ -654,25 +655,27 @@ def main_develop() -> None:
                            help="List all remote feature branches")
 
     args = parser.parse_args()
+    project_list: tp.List[LLVMProjects]
+    if "all" in args.projects:
+        project_list = generate_full_list_of_llvmprojects()
+    elif "all-vara" in args.projects:
+        project_list = generate_vara_list_of_llvmprojects()
+    else:
+        project_list = convert_to_llvmprojects_enum(args.projects)
+
     if args.command == 'new-branch':
-        dev.create_new_branch_for_projects(args.branch_name, args.projects)
+        dev.create_new_branch_for_projects(args.branch_name, project_list)
     elif args.command == 'checkout':
         if args.remote:
             dev.checkout_remote_branch_for_projects(args.branch_name,
-                                                    args.projects)
+                                                    project_list)
         else:
-            dev.checkout_branch_for_projects(args.branch_name, args.projects)
+            dev.checkout_branch_for_projects(args.branch_name, project_list)
     elif args.command == 'pull':
-        dev.pull_projects(args.projects)
+        dev.pull_projects(project_list)
     elif args.command == 'push':
-        dev.push_projects(args.projects)
+        dev.push_projects(project_list)
     elif args.command == 'status':
-        if "all" in args.projects:
-            project_list = generate_full_list_of_llvmprojects()
-        elif "all-vara" in args.projects:
-            project_list = generate_vara_list_of_llvmprojects()
-        else:
-            project_list = convert_to_llvmprojects_enum(args.projects)
         dev.show_status_for_projects(project_list)
     elif args.command == 'f-branches':
         dev.show_dev_branches([

--- a/varats/vara_manager.py
+++ b/varats/vara_manager.py
@@ -159,14 +159,14 @@ class LLVMProjects(Enum):
 
 
 def convert_to_llvmprojects_enum(projects_names: tp.List[str]
-                                 ) -> tp.List[LLVMProject]:
+                                 ) -> tp.List[LLVMProjects]:
     """
     Converts a list of strings into a list of LLVMProject.
     """
     enum_list = []
     for project_enum in LLVMProjects:
         if project_enum.name in projects_names:
-            enum_list.append(project_enum.project)
+            enum_list.append(project_enum)
             projects_names.remove(project_enum.name)
 
     if projects_names:
@@ -177,11 +177,11 @@ def convert_to_llvmprojects_enum(projects_names: tp.List[str]
     return enum_list
 
 
-def generate_full_list_of_llvmprojects() -> tp.List[LLVMProject]:
+def generate_full_list_of_llvmprojects() -> tp.List[LLVMProjects]:
     """
     Generates a list of all LLVM projects.
     """
-    return [project_enum.project for project_enum in LLVMProjects]
+    return [project_enum for project_enum in LLVMProjects]
 
 
 class VaRAProjectsIter():
@@ -203,11 +203,11 @@ class VaRAProjectsIter():
                 return val
 
 
-def generate_vara_list_of_llvmprojects() -> tp.List[LLVMProject]:
+def generate_vara_list_of_llvmprojects() -> tp.List[LLVMProjects]:
     """
     Generates a list of all VaRA llvm projects.
     """
-    return [project_enum.project for project_enum in VaRAProjectsIter()]
+    return [project_enum for project_enum in VaRAProjectsIter()]
 
 
 class VaRAExtraProjectsIter():


### PR DESCRIPTION
This PR extends the `vara-develop * all` modes (see #133) to the remaining sub-commands.
Closes se-passau/vara#490.