### PR TITLE
Release extender strategy

### DIFF
--- a/run_extra_tests.sh
+++ b/run_extra_tests.sh
@@ -33,6 +33,9 @@ check_err
 $COVERAGE $(which vara-cs) ext paper_configs/test/gzip_0.case_study -p gzip distrib_add --distribution uniform --num-rev 5 #gzip/
 check_err
 
+$COVERAGE $(which vara-cs) ext paper_configs/test/gzip_0.case_study -p gzip release_add --release-type major --merge-stage 4 #gzip/
+check_err
+
 $COVERAGE $(which vara-cs) status EmptyReport
 check_err
 

--- a/varats/driver.py
+++ b/varats/driver.py
@@ -29,7 +29,7 @@ from varats.utils.cli_util import cli_yn_choice
 from varats.utils.project_util import get_local_project_git_path
 from varats.paper.case_study import (
     SamplingMethod, ExtenderStrategy, extend_case_study, generate_case_study,
-    load_case_study_from_file, store_case_study)
+    load_case_study_from_file, store_case_study, ReleaseType)
 import varats.paper.paper_config_manager as PCM
 from varats.data.report import MetaReport
 
@@ -468,6 +468,8 @@ def main_casestudy() -> None:
         help="Extender strategy")
     ext_parser.add_argument(
         "--distribution", action=enum_action(SamplingMethod))
+    ext_parser.add_argument(
+        "--release-type", action=enum_action(ReleaseType))
     ext_parser.add_argument(
         "--merge-stage",
         default=-1,

--- a/varats/driver.py
+++ b/varats/driver.py
@@ -27,9 +27,10 @@ from varats.plots.plots import (extend_parser_with_plot_args, build_plot,
                                 PlotTypes)
 from varats.utils.cli_util import cli_yn_choice
 from varats.utils.project_util import get_local_project_git_path
-from varats.paper.case_study import (
-    SamplingMethod, ExtenderStrategy, extend_case_study, generate_case_study,
-    load_case_study_from_file, store_case_study, ReleaseType)
+from varats.paper.case_study import (SamplingMethod, ExtenderStrategy,
+                                     extend_case_study, generate_case_study,
+                                     load_case_study_from_file,
+                                     store_case_study, ReleaseType)
 import varats.paper.paper_config_manager as PCM
 from varats.data.report import MetaReport
 

--- a/varats/paper/case_study.py
+++ b/varats/paper/case_study.py
@@ -874,7 +874,8 @@ def extend_with_smooth_revs(case_study: CaseStudy, cmap: CommitMap,
 
 
 @check_required_args(['project', 'release_type', 'merge_stage'])
-def extend_with_release_revs(case_study, cmap, **kwargs) -> None:
+def extend_with_release_revs(case_study: CaseStudy, cmap: CommitMap,
+                             **kwargs: tp.Any) -> None:
     """
     Extend a case study with revisions marked as a release.
     This extender relies on the project to determine appropriate revisions.

--- a/varats/paper/case_study.py
+++ b/varats/paper/case_study.py
@@ -11,14 +11,14 @@ from pathlib import Path
 import errno
 import os
 import random
+
 import yaml
 from benchbuild.project import Project
-
 from scipy.stats import halfnorm
 import numpy as np
 import pygit2
-from varats.utils.project_util import get_project_cls_by_name
 
+from varats.utils.project_util import get_project_cls_by_name
 from varats.data.revisions import (get_processed_revisions,
                                    get_failed_revisions, get_tagged_revisions)
 from varats.plots.plot_utils import check_required_args
@@ -71,6 +71,14 @@ class SamplingMethod(Enum):
 
 
 class ReleaseType(Enum):
+    """
+    A ReleaseType referes to one of the three parts of the semantic versioning
+    specification.
+
+    It is assumed that a major release is also a minor release and that a minor
+    release is also a patch release.
+    """
+
     major = 1
     minor = 2
     patch = 3
@@ -83,8 +91,7 @@ class ReleaseType(Enum):
         """
         if other is None:
             return self
-        else:
-            return self if self.value >= other.value else other
+        return self if self.value >= other.value else other
 
 
 class ReleaseProvider():
@@ -883,8 +890,8 @@ def extend_with_release_revs(case_study: CaseStudy, cmap: CommitMap,
     project: Project = get_project_cls_by_name(kwargs['project'])
     release_revisions: tp.List[str] = project.get_release_revisions(
         kwargs['release_type'])
-    case_study.include_revisions([(rev, cmap.time_id(rev))
-                                  for rev in release_revisions],
-                                 kwargs['merge_stage'],
-                                 extender_strategy=ExtenderStrategy.release_add,
-                                 release_type=kwargs['release_type'])
+    case_study.include_revisions(
+        [(rev, cmap.time_id(rev)) for rev in release_revisions],
+        kwargs['merge_stage'],
+        extender_strategy=ExtenderStrategy.release_add,
+        release_type=kwargs['release_type'])

--- a/varats/projects/c_projects/gzip.py
+++ b/varats/projects/c_projects/gzip.py
@@ -56,7 +56,7 @@ class Gzip(prj.Project, ReleaseProvider):  # type: ignore
     @classmethod
     def get_release_revisions(cls, release_type: ReleaseType) -> tp.List[str]:
         major_release_regex = "^v[0-9]+\\.[0-9]+$"
-        minor_release_regex = "^v[0-9]+\\.[0-9]+\\.[0-9]+$"
+        minor_release_regex = "^v[0-9]+\\.[0-9]+(\\.[0-9]+)?$"
 
         tagged_commits = get_tagged_commits(cls.NAME)
         if release_type == ReleaseType.major:

--- a/varats/projects/c_projects/gzip.py
+++ b/varats/projects/c_projects/gzip.py
@@ -2,6 +2,7 @@
 Project file for gzip.
 """
 import re
+import typing as tp
 
 from benchbuild.settings import CFG
 from benchbuild.utils.cmd import make
@@ -11,7 +12,6 @@ from benchbuild.utils.run import run
 import benchbuild.project as prj
 
 from plumbum import local
-import typing as tp
 
 from varats.paper.case_study import ReleaseType, ReleaseProvider
 from varats.paper.paper_config import project_filter_generator

--- a/varats/projects/c_projects/gzip.py
+++ b/varats/projects/c_projects/gzip.py
@@ -1,6 +1,8 @@
 """
 Project file for gzip.
 """
+import re
+
 from benchbuild.settings import CFG
 from benchbuild.utils.cmd import make
 from benchbuild.utils.compiler import cc
@@ -9,8 +11,11 @@ from benchbuild.utils.run import run
 import benchbuild.project as prj
 
 from plumbum import local
+import typing as tp
 
+from varats.paper.case_study import ReleaseType, ReleaseProvider
 from varats.paper.paper_config import project_filter_generator
+from varats.utils.project_util import get_tagged_commits
 
 
 @with_git(
@@ -19,7 +24,7 @@ from varats.paper.paper_config import project_filter_generator
     refspec="HEAD",
     shallow_clone=False,
     version_filter=project_filter_generator("gzip"))
-class Gzip(prj.Project):  # type: ignore
+class Gzip(prj.Project, ReleaseProvider):  # type: ignore
     """ Compression and decompression tool Gzip (fetched by Git) """
 
     NAME = 'gzip'
@@ -47,3 +52,20 @@ class Gzip(prj.Project):  # type: ignore
                 run(local["./bootstrap"])
                 run(local["./configure"])
             run(make["-j", int(CFG["jobs"])])
+
+    @classmethod
+    def get_release_revisions(cls, release_type: ReleaseType) -> tp.List[str]:
+        major_release_regex = "^v[0-9]+\\.[0-9]+$"
+        minor_release_regex = "^v[0-9]+\\.[0-9]+\\.[0-9]+$"
+
+        tagged_commits = get_tagged_commits(cls.NAME)
+        if release_type == ReleaseType.major:
+            return [
+                h for h, tag in tagged_commits
+                if re.match(major_release_regex, tag)
+            ]
+        else:
+            return [
+                h for h, tag in tagged_commits
+                if re.match(minor_release_regex, tag)
+            ]

--- a/varats/utils/project_util.py
+++ b/varats/utils/project_util.py
@@ -5,7 +5,6 @@ Utility module for BenchBuild project handling.
 from pathlib import Path
 import typing as tp
 import tempfile
-from typing import List, Tuple
 
 from plumbum import local
 
@@ -68,7 +67,7 @@ def get_tagged_commits(project_name: str) -> tp.List[tp.Tuple[str, str]]:
         ref_list: tp.List[str] = git("show-ref", "--tags",
                                      "--dereference").strip().split("\n")
         ref_list = [ref for ref in ref_list if ref.endswith("^{}")]
-        refs: List[Tuple[str, str]] = [
+        refs: tp.List[tp.Tuple[str, str]] = [
             (ref_split[0], ref_split[1][10:-3])
             for ref_split in [ref.strip().split() for ref in ref_list]
         ]

--- a/varats/utils/project_util.py
+++ b/varats/utils/project_util.py
@@ -3,12 +3,15 @@ Utility module for BenchBuild project handling.
 """
 
 from pathlib import Path
+import typing as tp
 import tempfile
+from typing import List, Tuple
 
 from plumbum import local
 
 from benchbuild.project import ProjectRegistry, Project
 from benchbuild.settings import CFG as BB_CFG
+from benchbuild.utils.cmd import git
 from benchbuild.utils.download import Git
 from benchbuild.utils.settings import setup_config
 
@@ -52,3 +55,21 @@ def get_local_project_git_path(project_name: str) -> Path:
                     shallow_clone=False)
 
     return project_git_path
+
+
+def get_tagged_commits(project_name: str) -> tp.List[tp.Tuple[str, str]]:
+    """
+    Get a list of all tagged commits along with their respective tags.
+    """
+    repo_loc = get_local_project_git_path(project_name)
+    with local.cwd(repo_loc):
+        # --dereference resolves tag IDs into commits
+        # These lines are indicated by the suffix '^{}' (see man git-show-ref)
+        ref_list: tp.List[str] = git("show-ref", "--tags",
+                                     "--dereference").strip().split("\n")
+        ref_list = [ref for ref in ref_list if ref.endswith("^{}")]
+        refs: List[Tuple[str, str]] = [
+            (ref_split[0], ref_split[1][10:-3])
+            for ref_split in [ref.strip().split() for ref in ref_list]
+        ]
+        return refs


### PR DESCRIPTION
This PR adds a new case study extender that adds revisions identified as a release to the case study. Closes se-passau/VaRA#437

Releases can be further restricted to only _major_, _minor_ or _patch_ releases with the finer grained release types including the coarser ones.

The extender relies on the project to identify relevant commits. An example implementation for this mechanism is provided for the `gzip` project.