### PR TITLE
`vara develop checkout` fixes

### DIFF
--- a/varats/development.py
+++ b/varats/development.py
@@ -97,9 +97,8 @@ def checkout_branch_for_projects(branch_name: str,
                                                     project.project)
         if has_branch(llvm_folder / project.path, fixed_branch_name):
             checkout_branch(llvm_folder / project.path, fixed_branch_name)
-            print(
-                "Checked out new branch {branch} for project {project}".format(
-                    branch=fixed_branch_name, project=project.name))
+            print("Checked out existing branch {branch} for project {project}".
+                  format(branch=fixed_branch_name, project=project.name))
         else:
             print("No branch {branch} for project {project}".format(
                 branch=fixed_branch_name, project=project.name))
@@ -116,9 +115,9 @@ def checkout_remote_branch_for_projects(
         fixed_branch_name = __quickfix_dev_branches(branch_name,
                                                     project.project)
         if has_branch(llvm_folder / project.path, fixed_branch_name):
-            print(
-                "Checked out new branch {branch} for project {project}".format(
-                    branch=fixed_branch_name, project=project.name))
+            checkout_branch(llvm_folder / project.path, fixed_branch_name)
+            print("Checked out existing branch {branch} for project {project}".
+                  format(branch=fixed_branch_name, project=project.name))
             continue
 
         fetch_repository(llvm_folder / project.path)

--- a/varats/development.py
+++ b/varats/development.py
@@ -123,10 +123,12 @@ def checkout_remote_branch_for_projects(
         fetch_repository(llvm_folder / project.path)
         if has_remote_branch(llvm_folder / project.path, fixed_branch_name,
                              'origin'):
-            checkout_new_branch(llvm_folder / project.path, fixed_branch_name)
+            checkout_new_branch(llvm_folder / project.path, fixed_branch_name,
+                                'origin/' + fixed_branch_name)
             print(
-                "Checked out new branch {branch} for project {project}".format(
-                    branch=fixed_branch_name, project=project.name))
+                "Checked out new branch {branch} (tracking origin/{branch}) "
+                "for project {project}"
+                .format(branch=fixed_branch_name, project=project.name))
         else:
             print("No branch {branch} on remote origin for project {project}".
                   format(branch=fixed_branch_name, project=project.name))


### PR DESCRIPTION
This PR fixes the following bugs in the `vara-develop checkout` sub-command:

- `vd checkout -r <branch>` only printed a message if `<branch>` existed but did no checkout
- `vd checkout -r <branch>` did not properly setup remote branch-tracking
- the status messages of `vd checkout` always stated that a new branch was checked out, even if this branch already existed.