### PR TITLE
Adds `--sorted` option to `vara-cs status`

### DIFF
--- a/tests/paper/test_case_study.py
+++ b/tests/paper/test_case_study.py
@@ -2,8 +2,11 @@
 Test case study
 """
 import unittest
+import typing as tp
 from pathlib import Path
 from tempfile import NamedTemporaryFile
+
+from varats.data.reports.commit_report import CommitMap
 
 import varats.paper.case_study as CS
 
@@ -17,6 +20,8 @@ version: 1
 stages:
 - name: stage_0
   revisions:
+  - commit_hash: b8b25e7f1593f6dcc20660ff9fb1ed59ede15b7a
+    commit_id: 41
   - commit_hash: 7620b817357d6f14356afd004ace2da426cf8c36
     commit_id: 494
   - commit_hash: 622e9b1d024da1343b83fc47fb1891e1d245add3
@@ -35,14 +40,37 @@ stages:
     commit_id: 144
   - commit_hash: 9872ba420c99323195e96cafe56ff247c3011ad5
     commit_id: 56
-  - commit_hash: b8b25e7f1593f6dcc20660ff9fb1ed59ede15b7a
-    commit_id: 41
 - name: null
   revisions:
   - commit_hash: 7620b817357d6f14356afd004ace2da426cf8c36
     commit_id: 494
 ---
 """
+
+GIT_LOG_OUT = """7620b817357d6f14356afd004ace2da426cf8c36
+622e9b1d024da1343b83fc47fb1891e1d245add3
+8798d5c4fd520dcf91f36ebfa60bc5f3dca550d9
+2e654f9963154e5af9d3081fc871d54d783a1270
+edfad78619d52479e02228a5789a2e98d7b0f9f6
+a3db5806d012082b9e25cc36d09f19cd736a468f
+e75f428c0ddc90a7011cfda82a7114a16c537e34
+1e7e3769dc4efd55249c475470152acbcf804bb3
+9872ba420c99323195e96cafe56ff247c3011ad5
+b8b25e7f1593f6dcc20660ff9fb1ed59ede15b7a"""
+
+
+def mocked_create_lazy_commit_map_loader(project_name: str,
+                                         cmap_path: tp.Optional[Path] = None,
+                                         end: str = "HEAD",
+                                         start: tp.Optional[str] = None):
+    def get_test_case_study_cmap() -> CommitMap:
+        def format_stream():
+            for number, line in enumerate(reversed(GIT_LOG_OUT.split('\n'))):
+                yield "{}, {}\n".format(number, line)
+
+        return CommitMap(format_stream())
+
+    return get_test_case_study_cmap
 
 
 class TestCaseStudy(unittest.TestCase):

--- a/tests/paper/test_case_study.py
+++ b/tests/paper/test_case_study.py
@@ -17,8 +17,6 @@ version: 1
 stages:
 - name: stage_0
   revisions:
-  - commit_hash: b8b25e7f1593f6dcc20660ff9fb1ed59ede15b7a
-    commit_id: 41
   - commit_hash: 7620b817357d6f14356afd004ace2da426cf8c36
     commit_id: 494
   - commit_hash: 622e9b1d024da1343b83fc47fb1891e1d245add3
@@ -37,6 +35,8 @@ stages:
     commit_id: 144
   - commit_hash: 9872ba420c99323195e96cafe56ff247c3011ad5
     commit_id: 56
+  - commit_hash: b8b25e7f1593f6dcc20660ff9fb1ed59ede15b7a
+    commit_id: 41
 - name: null
   revisions:
   - commit_hash: 7620b817357d6f14356afd004ace2da426cf8c36

--- a/tests/paper/test_case_study.py
+++ b/tests/paper/test_case_study.py
@@ -17,6 +17,8 @@ version: 1
 stages:
 - name: stage_0
   revisions:
+  - commit_hash: b8b25e7f1593f6dcc20660ff9fb1ed59ede15b7a
+    commit_id: 41
   - commit_hash: 7620b817357d6f14356afd004ace2da426cf8c36
     commit_id: 494
   - commit_hash: 622e9b1d024da1343b83fc47fb1891e1d245add3
@@ -35,8 +37,6 @@ stages:
     commit_id: 144
   - commit_hash: 9872ba420c99323195e96cafe56ff247c3011ad5
     commit_id: 56
-  - commit_hash: b8b25e7f1593f6dcc20660ff9fb1ed59ede15b7a
-    commit_id: 41
 - name: null
   revisions:
   - commit_hash: 7620b817357d6f14356afd004ace2da426cf8c36

--- a/tests/paper/test_case_study.py
+++ b/tests/paper/test_case_study.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from tempfile import NamedTemporaryFile
 
 from varats.data.reports.commit_report import CommitMap
-
 import varats.paper.case_study as CS
 
 YAML_CASE_STUDY = """---

--- a/tests/paper/test_paper_config_manager.py
+++ b/tests/paper/test_paper_config_manager.py
@@ -93,10 +93,9 @@ class TestPaperConfigManager(unittest.TestCase):
             ('42b25e7f15', FileStatusExtension.Success)
         ]
 
-        status = PCM.get_status(self.case_study, CommitReport, 5, False, False)
+        status = PCM.get_status(self.case_study, CommitReport, 5, False)
         self.assertEqual(
             status, """CS: gzip_1: (  0/10) processed [0/0/0/10/0]
-    b8b25e7f15 [Missing]
     7620b81735 [Missing]
     622e9b1d02 [Missing]
     8798d5c4fd [Missing]
@@ -106,6 +105,7 @@ class TestPaperConfigManager(unittest.TestCase):
     e75f428c0d [Missing]
     1e7e3769dc [Missing]
     9872ba420c [Missing]
+    b8b25e7f15 [Missing]
 """)
         mock_get_tagged_revisions.assert_called()
 
@@ -117,31 +117,7 @@ class TestPaperConfigManager(unittest.TestCase):
             ('2e654f9963', FileStatusExtension.Blocked)
         ]
 
-        status = PCM.get_status(self.case_study, CommitReport, 5, False, False)
-        self.assertEqual(
-            status, """CS: gzip_1: (  1/10) processed [1/1/1/6/1]
-    b8b25e7f15 [Success]
-    7620b81735 [Missing]
-    622e9b1d02 [Failed]
-    8798d5c4fd [Missing]
-    2e654f9963 [Blocked]
-    edfad78619 [Missing]
-    a3db5806d0 [Missing]
-    e75f428c0d [Missing]
-    1e7e3769dc [CompileError]
-    9872ba420c [Missing]
-""")
-        mock_get_tagged_revisions.assert_called()
-
-        mock_get_tagged_revisions.reset_mock()
-        mock_get_tagged_revisions.return_value = [
-            ('b8b25e7f15', FileStatusExtension.Success),
-            ('622e9b1d02', FileStatusExtension.Failed),
-            ('1e7e3769dc', FileStatusExtension.CompileError),
-            ('2e654f9963', FileStatusExtension.Blocked)
-        ]
-
-        status = PCM.get_status(self.case_study, CommitReport, 5, False, True)
+        status = PCM.get_status(self.case_study, CommitReport, 5, False)
         self.assertEqual(
             status, """CS: gzip_1: (  1/10) processed [1/1/1/6/1]
     7620b81735 [Missing]
@@ -167,11 +143,10 @@ class TestPaperConfigManager(unittest.TestCase):
             ('42b25e7f15', FileStatusExtension.Success)
         ]
 
-        status = PCM.get_status(self.case_study, CommitReport, 5, True, False)
+        status = PCM.get_status(self.case_study, CommitReport, 5, True)
         self.assertEqual(
             status, """CS: gzip_1: (  0/10) processed [0/0/0/10/0]
   Stage 0 (stage_0)
-    b8b25e7f15 [Missing]
     7620b81735 [Missing]
     622e9b1d02 [Missing]
     8798d5c4fd [Missing]
@@ -181,6 +156,7 @@ class TestPaperConfigManager(unittest.TestCase):
     e75f428c0d [Missing]
     1e7e3769dc [Missing]
     9872ba420c [Missing]
+    b8b25e7f15 [Missing]
   Stage 1
     7620b81735 [Missing]
 """)
@@ -194,34 +170,7 @@ class TestPaperConfigManager(unittest.TestCase):
             ('2e654f9963', FileStatusExtension.Blocked)
         ]
 
-        status = PCM.get_status(self.case_study, CommitReport, 5, True, False)
-        self.assertEqual(
-            status, """CS: gzip_1: (  1/10) processed [1/1/1/6/1]
-  Stage 0 (stage_0)
-    b8b25e7f15 [Success]
-    7620b81735 [Missing]
-    622e9b1d02 [Failed]
-    8798d5c4fd [Missing]
-    2e654f9963 [Blocked]
-    edfad78619 [Missing]
-    a3db5806d0 [Missing]
-    e75f428c0d [Missing]
-    1e7e3769dc [CompileError]
-    9872ba420c [Missing]
-  Stage 1
-    7620b81735 [Missing]
-""")
-        mock_get_tagged_revisions.assert_called()
-
-        mock_get_tagged_revisions.reset_mock()
-        mock_get_tagged_revisions.return_value = [
-            ('b8b25e7f15', FileStatusExtension.Success),
-            ('622e9b1d02', FileStatusExtension.Failed),
-            ('1e7e3769dc', FileStatusExtension.CompileError),
-            ('2e654f9963', FileStatusExtension.Blocked)
-        ]
-
-        status = PCM.get_status(self.case_study, CommitReport, 5, True, True)
+        status = PCM.get_status(self.case_study, CommitReport, 5, True)
         self.assertEqual(
             status, """CS: gzip_1: (  1/10) processed [1/1/1/6/1]
   Stage 0 (stage_0)
@@ -253,10 +202,9 @@ class TestPaperConfigManager(unittest.TestCase):
             ('42b25e7f15', FileStatusExtension.Success)
         ]
 
-        status = PCM.get_status(self.case_study, CommitReport, 5, False, False)
+        status = PCM.get_status(self.case_study, CommitReport, 5, False, True)
         self.assertEqual(
             status, """CS: gzip_1: (  0/10) processed [0/0/0/10/0]
-    b8b25e7f15 [Missing]
     7620b81735 [Missing]
     622e9b1d02 [Missing]
     8798d5c4fd [Missing]
@@ -266,6 +214,7 @@ class TestPaperConfigManager(unittest.TestCase):
     e75f428c0d [Missing]
     1e7e3769dc [Missing]
     9872ba420c [Missing]
+    b8b25e7f15 [Missing]
 """)
         mock_get_tagged_revisions.assert_called()
 
@@ -277,10 +226,9 @@ class TestPaperConfigManager(unittest.TestCase):
             ('2e654f9963', FileStatusExtension.Blocked)
         ]
 
-        status = PCM.get_status(self.case_study, CommitReport, 5, False, False)
+        status = PCM.get_status(self.case_study, CommitReport, 5, False, True)
         self.assertEqual(
             status, """CS: gzip_1: (  1/10) processed [1/1/1/6/1]
-    b8b25e7f15 [Success]
     7620b81735 [Missing]
     622e9b1d02 [Failed]
     8798d5c4fd [Missing]
@@ -290,6 +238,7 @@ class TestPaperConfigManager(unittest.TestCase):
     e75f428c0d [Missing]
     1e7e3769dc [CompileError]
     9872ba420c [Missing]
+    b8b25e7f15 [Success]
 """)
         mock_get_tagged_revisions.assert_called()
 
@@ -324,7 +273,7 @@ class TestPaperConfigManager(unittest.TestCase):
             ('42b25e7f15', FileStatusExtension.Success)
         ]
 
-        PCM.get_status(self.case_study, CommitReport, 5, False, False, True,
+        PCM.get_status(self.case_study, CommitReport, 5, False, True,
                        total_status_occurrences)
         status = PCM.get_total_status(total_status_occurrences, 15, True)
         self.assertEqual(
@@ -342,7 +291,7 @@ Total:         (  0/10) processed [0/0/0/10/0]""")
             ('2e654f9963', FileStatusExtension.Blocked)
         ]
 
-        PCM.get_status(self.case_study, CommitReport, 5, False, False, True,
+        PCM.get_status(self.case_study, CommitReport, 5, False, True,
                        total_status_occurrences)
         status = PCM.get_total_status(total_status_occurrences, 15, True)
         self.assertEqual(
@@ -363,7 +312,7 @@ Total:         (  1/14) processed [1/1/1/10/1]""")
             ('2e654f9963', FileStatusExtension.Blocked)
         ]
 
-        PCM.get_status(self.case_study, CommitReport, 5, False, False, True,
+        PCM.get_status(self.case_study, CommitReport, 5, False, True,
                        total_status_occurrences)
         status = PCM.get_total_status(total_status_occurrences, 15, True)
         self.assertEqual(

--- a/tests/paper/test_paper_config_manager.py
+++ b/tests/paper/test_paper_config_manager.py
@@ -11,6 +11,7 @@ from tempfile import NamedTemporaryFile
 import yaml
 import mock
 
+from tests.paper.test_case_study import mocked_create_lazy_commit_map_loader
 from varats.data.report import FileStatusExtension
 from varats.data.reports.commit_report import CommitReport
 import varats.paper.paper_config_manager as PCM
@@ -83,8 +84,11 @@ class TestPaperConfigManager(unittest.TestCase):
         self.assertEqual(status, 'CS: gzip_1: (  1/10) processed [1/0/0/9/0]')
         mock_get_tagged_revisions.assert_called()
 
+    @mock.patch(
+        'varats.paper.paper_config_manager.create_lazy_commit_map_loader',
+        side_effect=mocked_create_lazy_commit_map_loader)
     @mock.patch('varats.paper.case_study.get_tagged_revisions')
-    def test_status(self, mock_get_tagged_revisions):
+    def test_status(self, mock_get_tagged_revisions, mock_cmap_loader):
         """
         Check if the case study can show a short status.
         """
@@ -96,6 +100,7 @@ class TestPaperConfigManager(unittest.TestCase):
         status = PCM.get_status(self.case_study, CommitReport, 5, False, False)
         self.assertEqual(
             status, """CS: gzip_1: (  0/10) processed [0/0/0/10/0]
+    b8b25e7f15 [Missing]
     7620b81735 [Missing]
     622e9b1d02 [Missing]
     8798d5c4fd [Missing]
@@ -105,7 +110,6 @@ class TestPaperConfigManager(unittest.TestCase):
     e75f428c0d [Missing]
     1e7e3769dc [Missing]
     9872ba420c [Missing]
-    b8b25e7f15 [Missing]
 """)
         mock_get_tagged_revisions.assert_called()
 
@@ -118,6 +122,30 @@ class TestPaperConfigManager(unittest.TestCase):
         ]
 
         status = PCM.get_status(self.case_study, CommitReport, 5, False, False)
+        self.assertEqual(
+            status, """CS: gzip_1: (  1/10) processed [1/1/1/6/1]
+    b8b25e7f15 [Success]
+    7620b81735 [Missing]
+    622e9b1d02 [Failed]
+    8798d5c4fd [Missing]
+    2e654f9963 [Blocked]
+    edfad78619 [Missing]
+    a3db5806d0 [Missing]
+    e75f428c0d [Missing]
+    1e7e3769dc [CompileError]
+    9872ba420c [Missing]
+""")
+        mock_get_tagged_revisions.assert_called()
+
+        mock_get_tagged_revisions.reset_mock()
+        mock_get_tagged_revisions.return_value = [
+            ('b8b25e7f15', FileStatusExtension.Success),
+            ('622e9b1d02', FileStatusExtension.Failed),
+            ('1e7e3769dc', FileStatusExtension.CompileError),
+            ('2e654f9963', FileStatusExtension.Blocked)
+        ]
+
+        status = PCM.get_status(self.case_study, CommitReport, 5, False, True)
         self.assertEqual(
             status, """CS: gzip_1: (  1/10) processed [1/1/1/6/1]
     7620b81735 [Missing]
@@ -133,8 +161,12 @@ class TestPaperConfigManager(unittest.TestCase):
 """)
         mock_get_tagged_revisions.assert_called()
 
+    @mock.patch(
+        'varats.paper.paper_config_manager.create_lazy_commit_map_loader',
+        side_effect=mocked_create_lazy_commit_map_loader)
     @mock.patch('varats.paper.case_study.get_tagged_revisions')
-    def test_status_with_stages(self, mock_get_tagged_revisions):
+    def test_status_with_stages(self, mock_get_tagged_revisions,
+                                mock_cmap_loader):
         """
         Check if the case study can show a short status.
         """
@@ -147,6 +179,7 @@ class TestPaperConfigManager(unittest.TestCase):
         self.assertEqual(
             status, """CS: gzip_1: (  0/10) processed [0/0/0/10/0]
   Stage 0 (stage_0)
+    b8b25e7f15 [Missing]
     7620b81735 [Missing]
     622e9b1d02 [Missing]
     8798d5c4fd [Missing]
@@ -156,7 +189,6 @@ class TestPaperConfigManager(unittest.TestCase):
     e75f428c0d [Missing]
     1e7e3769dc [Missing]
     9872ba420c [Missing]
-    b8b25e7f15 [Missing]
   Stage 1
     7620b81735 [Missing]
 """)
@@ -171,6 +203,33 @@ class TestPaperConfigManager(unittest.TestCase):
         ]
 
         status = PCM.get_status(self.case_study, CommitReport, 5, True, False)
+        self.assertEqual(
+            status, """CS: gzip_1: (  1/10) processed [1/1/1/6/1]
+  Stage 0 (stage_0)
+    b8b25e7f15 [Success]
+    7620b81735 [Missing]
+    622e9b1d02 [Failed]
+    8798d5c4fd [Missing]
+    2e654f9963 [Blocked]
+    edfad78619 [Missing]
+    a3db5806d0 [Missing]
+    e75f428c0d [Missing]
+    1e7e3769dc [CompileError]
+    9872ba420c [Missing]
+  Stage 1
+    7620b81735 [Missing]
+""")
+        mock_get_tagged_revisions.assert_called()
+
+        mock_get_tagged_revisions.reset_mock()
+        mock_get_tagged_revisions.return_value = [
+            ('b8b25e7f15', FileStatusExtension.Success),
+            ('622e9b1d02', FileStatusExtension.Failed),
+            ('1e7e3769dc', FileStatusExtension.CompileError),
+            ('2e654f9963', FileStatusExtension.Blocked)
+        ]
+
+        status = PCM.get_status(self.case_study, CommitReport, 5, True, True)
         self.assertEqual(
             status, """CS: gzip_1: (  1/10) processed [1/1/1/6/1]
   Stage 0 (stage_0)
@@ -202,9 +261,11 @@ class TestPaperConfigManager(unittest.TestCase):
             ('42b25e7f15', FileStatusExtension.Success)
         ]
 
-        status = PCM.get_status(self.case_study, CommitReport, 5, False, True)
+        status = PCM.get_status(self.case_study, CommitReport, 5, False, False,
+                                True)
         self.assertEqual(
             status, """CS: gzip_1: (  0/10) processed [0/0/0/10/0]
+    b8b25e7f15 [Missing]
     7620b81735 [Missing]
     622e9b1d02 [Missing]
     8798d5c4fd [Missing]
@@ -214,7 +275,6 @@ class TestPaperConfigManager(unittest.TestCase):
     e75f428c0d [Missing]
     1e7e3769dc [Missing]
     9872ba420c [Missing]
-    b8b25e7f15 [Missing]
 """)
         mock_get_tagged_revisions.assert_called()
 
@@ -226,9 +286,11 @@ class TestPaperConfigManager(unittest.TestCase):
             ('2e654f9963', FileStatusExtension.Blocked)
         ]
 
-        status = PCM.get_status(self.case_study, CommitReport, 5, False, True)
+        status = PCM.get_status(self.case_study, CommitReport, 5, False, False,
+                                True)
         self.assertEqual(
             status, """CS: gzip_1: (  1/10) processed [1/1/1/6/1]
+    b8b25e7f15 [Success]
     7620b81735 [Missing]
     622e9b1d02 [Failed]
     8798d5c4fd [Missing]
@@ -238,7 +300,6 @@ class TestPaperConfigManager(unittest.TestCase):
     e75f428c0d [Missing]
     1e7e3769dc [CompileError]
     9872ba420c [Missing]
-    b8b25e7f15 [Success]
 """)
         mock_get_tagged_revisions.assert_called()
 
@@ -252,14 +313,12 @@ class TestPaperConfigManager(unittest.TestCase):
         self.assertEqual(
             PCM.get_legend(True),
             """CS: project_42: (Success / Total) processed [Success/Failed/CompileError/Missing/Blocked]
-"""
-        )
+""")
 
         self.assertEqual(
             PCM.get_legend(False),
             """CS: project_42: (Success / Total) processed [Success/Failed/CompileError/Missing/Blocked]
-"""
-        )
+""")
 
     @mock.patch('varats.paper.case_study.get_tagged_revisions')
     def test_total_status_color(self, mock_get_tagged_revisions):

--- a/tests/paper/test_paper_config_manager.py
+++ b/tests/paper/test_paper_config_manager.py
@@ -93,7 +93,7 @@ class TestPaperConfigManager(unittest.TestCase):
             ('42b25e7f15', FileStatusExtension.Success)
         ]
 
-        status = PCM.get_status(self.case_study, CommitReport, 5, False)
+        status = PCM.get_status(self.case_study, CommitReport, 5, False, False)
         self.assertEqual(
             status, """CS: gzip_1: (  0/10) processed [0/0/0/10/0]
     7620b81735 [Missing]
@@ -117,7 +117,7 @@ class TestPaperConfigManager(unittest.TestCase):
             ('2e654f9963', FileStatusExtension.Blocked)
         ]
 
-        status = PCM.get_status(self.case_study, CommitReport, 5, False)
+        status = PCM.get_status(self.case_study, CommitReport, 5, False, False)
         self.assertEqual(
             status, """CS: gzip_1: (  1/10) processed [1/1/1/6/1]
     7620b81735 [Missing]
@@ -143,7 +143,7 @@ class TestPaperConfigManager(unittest.TestCase):
             ('42b25e7f15', FileStatusExtension.Success)
         ]
 
-        status = PCM.get_status(self.case_study, CommitReport, 5, True)
+        status = PCM.get_status(self.case_study, CommitReport, 5, True, False)
         self.assertEqual(
             status, """CS: gzip_1: (  0/10) processed [0/0/0/10/0]
   Stage 0 (stage_0)
@@ -170,7 +170,7 @@ class TestPaperConfigManager(unittest.TestCase):
             ('2e654f9963', FileStatusExtension.Blocked)
         ]
 
-        status = PCM.get_status(self.case_study, CommitReport, 5, True)
+        status = PCM.get_status(self.case_study, CommitReport, 5, True, False)
         self.assertEqual(
             status, """CS: gzip_1: (  1/10) processed [1/1/1/6/1]
   Stage 0 (stage_0)
@@ -273,7 +273,7 @@ class TestPaperConfigManager(unittest.TestCase):
             ('42b25e7f15', FileStatusExtension.Success)
         ]
 
-        PCM.get_status(self.case_study, CommitReport, 5, False, True,
+        PCM.get_status(self.case_study, CommitReport, 5, False, False, True,
                        total_status_occurrences)
         status = PCM.get_total_status(total_status_occurrences, 15, True)
         self.assertEqual(
@@ -291,7 +291,7 @@ Total:         (  0/10) processed [0/0/0/10/0]""")
             ('2e654f9963', FileStatusExtension.Blocked)
         ]
 
-        PCM.get_status(self.case_study, CommitReport, 5, False, True,
+        PCM.get_status(self.case_study, CommitReport, 5, False, False, True,
                        total_status_occurrences)
         status = PCM.get_total_status(total_status_occurrences, 15, True)
         self.assertEqual(
@@ -312,7 +312,7 @@ Total:         (  1/14) processed [1/1/1/10/1]""")
             ('2e654f9963', FileStatusExtension.Blocked)
         ]
 
-        PCM.get_status(self.case_study, CommitReport, 5, False, True,
+        PCM.get_status(self.case_study, CommitReport, 5, False, False, True,
                        total_status_occurrences)
         status = PCM.get_total_status(total_status_occurrences, 15, True)
         self.assertEqual(

--- a/tests/paper/test_paper_config_manager.py
+++ b/tests/paper/test_paper_config_manager.py
@@ -93,9 +93,10 @@ class TestPaperConfigManager(unittest.TestCase):
             ('42b25e7f15', FileStatusExtension.Success)
         ]
 
-        status = PCM.get_status(self.case_study, CommitReport, 5, False)
+        status = PCM.get_status(self.case_study, CommitReport, 5, False, False)
         self.assertEqual(
             status, """CS: gzip_1: (  0/10) processed [0/0/0/10/0]
+    b8b25e7f15 [Missing]
     7620b81735 [Missing]
     622e9b1d02 [Missing]
     8798d5c4fd [Missing]
@@ -105,7 +106,6 @@ class TestPaperConfigManager(unittest.TestCase):
     e75f428c0d [Missing]
     1e7e3769dc [Missing]
     9872ba420c [Missing]
-    b8b25e7f15 [Missing]
 """)
         mock_get_tagged_revisions.assert_called()
 
@@ -117,7 +117,31 @@ class TestPaperConfigManager(unittest.TestCase):
             ('2e654f9963', FileStatusExtension.Blocked)
         ]
 
-        status = PCM.get_status(self.case_study, CommitReport, 5, False)
+        status = PCM.get_status(self.case_study, CommitReport, 5, False, False)
+        self.assertEqual(
+            status, """CS: gzip_1: (  1/10) processed [1/1/1/6/1]
+    b8b25e7f15 [Success]
+    7620b81735 [Missing]
+    622e9b1d02 [Failed]
+    8798d5c4fd [Missing]
+    2e654f9963 [Blocked]
+    edfad78619 [Missing]
+    a3db5806d0 [Missing]
+    e75f428c0d [Missing]
+    1e7e3769dc [CompileError]
+    9872ba420c [Missing]
+""")
+        mock_get_tagged_revisions.assert_called()
+
+        mock_get_tagged_revisions.reset_mock()
+        mock_get_tagged_revisions.return_value = [
+            ('b8b25e7f15', FileStatusExtension.Success),
+            ('622e9b1d02', FileStatusExtension.Failed),
+            ('1e7e3769dc', FileStatusExtension.CompileError),
+            ('2e654f9963', FileStatusExtension.Blocked)
+        ]
+
+        status = PCM.get_status(self.case_study, CommitReport, 5, False, True)
         self.assertEqual(
             status, """CS: gzip_1: (  1/10) processed [1/1/1/6/1]
     7620b81735 [Missing]
@@ -143,10 +167,11 @@ class TestPaperConfigManager(unittest.TestCase):
             ('42b25e7f15', FileStatusExtension.Success)
         ]
 
-        status = PCM.get_status(self.case_study, CommitReport, 5, True)
+        status = PCM.get_status(self.case_study, CommitReport, 5, True, False)
         self.assertEqual(
             status, """CS: gzip_1: (  0/10) processed [0/0/0/10/0]
   Stage 0 (stage_0)
+    b8b25e7f15 [Missing]
     7620b81735 [Missing]
     622e9b1d02 [Missing]
     8798d5c4fd [Missing]
@@ -156,7 +181,6 @@ class TestPaperConfigManager(unittest.TestCase):
     e75f428c0d [Missing]
     1e7e3769dc [Missing]
     9872ba420c [Missing]
-    b8b25e7f15 [Missing]
   Stage 1
     7620b81735 [Missing]
 """)
@@ -170,7 +194,34 @@ class TestPaperConfigManager(unittest.TestCase):
             ('2e654f9963', FileStatusExtension.Blocked)
         ]
 
-        status = PCM.get_status(self.case_study, CommitReport, 5, True)
+        status = PCM.get_status(self.case_study, CommitReport, 5, True, False)
+        self.assertEqual(
+            status, """CS: gzip_1: (  1/10) processed [1/1/1/6/1]
+  Stage 0 (stage_0)
+    b8b25e7f15 [Success]
+    7620b81735 [Missing]
+    622e9b1d02 [Failed]
+    8798d5c4fd [Missing]
+    2e654f9963 [Blocked]
+    edfad78619 [Missing]
+    a3db5806d0 [Missing]
+    e75f428c0d [Missing]
+    1e7e3769dc [CompileError]
+    9872ba420c [Missing]
+  Stage 1
+    7620b81735 [Missing]
+""")
+        mock_get_tagged_revisions.assert_called()
+
+        mock_get_tagged_revisions.reset_mock()
+        mock_get_tagged_revisions.return_value = [
+            ('b8b25e7f15', FileStatusExtension.Success),
+            ('622e9b1d02', FileStatusExtension.Failed),
+            ('1e7e3769dc', FileStatusExtension.CompileError),
+            ('2e654f9963', FileStatusExtension.Blocked)
+        ]
+
+        status = PCM.get_status(self.case_study, CommitReport, 5, True, True)
         self.assertEqual(
             status, """CS: gzip_1: (  1/10) processed [1/1/1/6/1]
   Stage 0 (stage_0)
@@ -202,9 +253,10 @@ class TestPaperConfigManager(unittest.TestCase):
             ('42b25e7f15', FileStatusExtension.Success)
         ]
 
-        status = PCM.get_status(self.case_study, CommitReport, 5, False, True)
+        status = PCM.get_status(self.case_study, CommitReport, 5, False, False)
         self.assertEqual(
             status, """CS: gzip_1: (  0/10) processed [0/0/0/10/0]
+    b8b25e7f15 [Missing]
     7620b81735 [Missing]
     622e9b1d02 [Missing]
     8798d5c4fd [Missing]
@@ -214,7 +266,6 @@ class TestPaperConfigManager(unittest.TestCase):
     e75f428c0d [Missing]
     1e7e3769dc [Missing]
     9872ba420c [Missing]
-    b8b25e7f15 [Missing]
 """)
         mock_get_tagged_revisions.assert_called()
 
@@ -226,9 +277,10 @@ class TestPaperConfigManager(unittest.TestCase):
             ('2e654f9963', FileStatusExtension.Blocked)
         ]
 
-        status = PCM.get_status(self.case_study, CommitReport, 5, False, True)
+        status = PCM.get_status(self.case_study, CommitReport, 5, False, False)
         self.assertEqual(
             status, """CS: gzip_1: (  1/10) processed [1/1/1/6/1]
+    b8b25e7f15 [Success]
     7620b81735 [Missing]
     622e9b1d02 [Failed]
     8798d5c4fd [Missing]
@@ -238,7 +290,6 @@ class TestPaperConfigManager(unittest.TestCase):
     e75f428c0d [Missing]
     1e7e3769dc [CompileError]
     9872ba420c [Missing]
-    b8b25e7f15 [Success]
 """)
         mock_get_tagged_revisions.assert_called()
 
@@ -273,7 +324,7 @@ class TestPaperConfigManager(unittest.TestCase):
             ('42b25e7f15', FileStatusExtension.Success)
         ]
 
-        PCM.get_status(self.case_study, CommitReport, 5, False, True,
+        PCM.get_status(self.case_study, CommitReport, 5, False, False, True,
                        total_status_occurrences)
         status = PCM.get_total_status(total_status_occurrences, 15, True)
         self.assertEqual(
@@ -291,7 +342,7 @@ Total:         (  0/10) processed [0/0/0/10/0]""")
             ('2e654f9963', FileStatusExtension.Blocked)
         ]
 
-        PCM.get_status(self.case_study, CommitReport, 5, False, True,
+        PCM.get_status(self.case_study, CommitReport, 5, False, False, True,
                        total_status_occurrences)
         status = PCM.get_total_status(total_status_occurrences, 15, True)
         self.assertEqual(
@@ -312,7 +363,7 @@ Total:         (  1/14) processed [1/1/1/10/1]""")
             ('2e654f9963', FileStatusExtension.Blocked)
         ]
 
-        PCM.get_status(self.case_study, CommitReport, 5, False, True,
+        PCM.get_status(self.case_study, CommitReport, 5, False, False, True,
                        total_status_occurrences)
         status = PCM.get_total_status(total_status_occurrences, 15, True)
         self.assertEqual(

--- a/varats/driver.py
+++ b/varats/driver.py
@@ -414,6 +414,11 @@ def main_casestudy() -> None:
         action="store_true",
         default=False)
     status_parser.add_argument(
+        "--sorted",
+        help="Sort the revisions in the order they are printed by git log.",
+        action="store_true",
+        default=False)
+    status_parser.add_argument(
         "--legend",
         help="Print status with legend",
         action="store_true",
@@ -533,7 +538,7 @@ def main_casestudy() -> None:
 
         PCM.show_status_of_case_studies(
             args['report_name'], args['filter_regex'], args['short'],
-            args['list_revs'], args['ws'], args['legend'])
+            args['sorted'], args['list_revs'], args['ws'], args['legend'])
 
     elif args['subcommand'] == 'gen' or args['subcommand'] == 'ext':
         if "project" not in args and "git_path" not in args:

--- a/varats/tools/commit_map.py
+++ b/varats/tools/commit_map.py
@@ -76,7 +76,7 @@ def get_commit_map(project_name: str,
 
 def create_lazy_commit_map_loader(
         project_name: str,
-        cmap_path: Path,
+        cmap_path: tp.Optional[Path] = None,
         end: str = "HEAD",
         start: tp.Optional[str] = None) -> tp.Callable[[], CommitMap]:
     """


### PR DESCRIPTION
This PR introduces a new option `--sorted` to the command `vara-cs status`.
With this option, the revisions are sorted according to their time id before printing.
If `--ws` is given, sorting is done per-stage.