### PR TITLE
Implements FileStatus White/Blacklisting

### DIFF
--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -1,0 +1,21 @@
+"""
+Small helper classes for testing
+"""
+
+from benchbuild.project import Project
+
+
+class EmptyProject(Project):
+    NAME = "test_empty"
+    DOMAIN = "debug"
+    GROUP = "debug"
+    SRC_FILE = "none"
+
+    def build(self):
+        pass
+
+    def configure(self):
+        pass
+
+    def download(self):
+        pass

--- a/tests/utils/test_experiment_util.py
+++ b/tests/utils/test_experiment_util.py
@@ -26,7 +26,7 @@ class MockExperiment(EU.VaRAVersionExperiment):
 
 class TestVaRAVersionExperiment(unittest.TestCase):
     """
-    Test if a blame inst interactions are correctly reconstruction from yaml.
+    Test VersionExperiments sampling behaviour.
     """
     @classmethod
     def setUpClass(cls):
@@ -140,7 +140,7 @@ class TestVaRAVersionExperiment(unittest.TestCase):
     @mock.patch('varats.utils.experiment_util.get_tagged_revisions')
     def test_only_blacklisting_one(self, mock_get_tagged_revisions):
         """
-        Test if we can whitelist file status
+        Test if we can blacklist file status
         """
         EU.CFG["versions"]["full"] = True
         # Revision not in set
@@ -168,7 +168,7 @@ class TestVaRAVersionExperiment(unittest.TestCase):
     @mock.patch('varats.utils.experiment_util.get_tagged_revisions')
     def test_only_blacklisting_many(self, mock_get_tagged_revisions):
         """
-        Test if we can whitelist file status
+        Test if we can blacklist file status
         """
         EU.CFG["versions"]["full"] = True
         # Revision not in set
@@ -196,7 +196,7 @@ class TestVaRAVersionExperiment(unittest.TestCase):
     @mock.patch('varats.utils.experiment_util.get_tagged_revisions')
     def test_white_overwrite_blacklisting(self, mock_get_tagged_revisions):
         """
-        Test if we can whitelist file status
+        Test if whitelist overwrites blacklist
         """
         EU.CFG["versions"]["full"] = True
         # Revision not in set

--- a/tests/utils/test_experiment_util.py
+++ b/tests/utils/test_experiment_util.py
@@ -1,0 +1,220 @@
+"""
+Test VaRA Experiment utilities
+"""
+import typing as tp
+import unittest
+import unittest.mock as mock
+
+import benchbuild.utils.settings as s
+import benchbuild.utils.actions as actions
+from benchbuild.project import Project
+
+import varats.utils.experiment_util as EU
+from varats.data.reports.commit_report import CommitReport as CR
+from varats.data.report import FileStatusExtension
+
+from tests.test_helper import EmptyProject
+
+
+class MockExperiment(EU.VaRAVersionExperiment):
+    NAME = "GitBlameAnnotationReport"
+    REPORT_TYPE = CR
+
+    def actions_for_project(self, project: Project) -> tp.List[actions.Step]:
+        return []
+
+
+class TestVaRAVersionExperiment(unittest.TestCase):
+    """
+    Test if a blame inst interactions are correctly reconstruction from yaml.
+    """
+    @classmethod
+    def setUpClass(cls):
+        """
+        Load and parse function infos from yaml file.
+        """
+        EU.V_CFG = s.Configuration("vara", node={})
+        EU.V_CFG['experiment'] = {
+            "file_status_blacklist": {
+                "default": [],
+            },
+            "file_status_whitelist": {
+                "default": [],
+            },
+            "random_order": {
+                "default": False,
+            },
+            "sample_limit": {
+                "default": None,
+            },
+        }
+        s.setup_config(EU.V_CFG)
+        cls.vers_expr = MockExperiment()
+        cls.rev_list = ['rev1', 'rev2', 'rev3', 'rev4', 'rev5']
+
+    def setUp(self):
+        """Set config to initial values."""
+        EU.V_CFG["experiment"]["sample_limit"] = None
+        EU.V_CFG["experiment"]["random_order"] = False
+        EU.V_CFG["experiment"]["file_status_whitelist"] = []
+        EU.V_CFG["experiment"]["file_status_blacklist"] = []
+        EU.CFG["versions"]["full"] = False
+        self.rev_list = ['rev1', 'rev2', 'rev3', 'rev4', 'rev5']
+
+    def test_sample_limit(self):
+        """
+        Test if base_hash is loaded correctly.
+        """
+        self.assertEqual(EU.V_CFG["experiment"]["sample_limit"].value, None)
+        self.assertEqual(self.vers_expr._sample_num_versions(self.rev_list),
+                         self.rev_list)
+
+        EU.V_CFG["experiment"]["sample_limit"] = 3
+        self.assertEqual(
+            len(self.vers_expr._sample_num_versions(self.rev_list)), 3)
+
+    def test_without_versions(self):
+        """
+        Test if we get the correct revision if no VaRA modifications are enabled.
+        """
+        prj = EmptyProject(self.vers_expr)
+        sample_gen = self.vers_expr.sample(prj, self.rev_list)
+        self.assertEqual(next(sample_gen), "rev1")
+        with self.assertRaises(StopIteration):
+            next(sample_gen)
+
+    @mock.patch('varats.utils.experiment_util.get_tagged_revisions')
+    def test_only_whitelisting_one(self, mock_get_tagged_revisions):
+        """
+        Test if we can whitelist file status
+        """
+        EU.CFG["versions"]["full"] = True
+        # Revision not in set
+        mock_get_tagged_revisions.return_value = [
+            ('rev1', FileStatusExtension.Success),
+            ('rev2', FileStatusExtension.Blocked),
+            ('rev3', FileStatusExtension.CompileError),
+            ('rev4', FileStatusExtension.Failed),
+            ('rev5', FileStatusExtension.Missing)
+        ]
+
+        EU.V_CFG["experiment"]["file_status_whitelist"] = ['success']
+
+        prj = EmptyProject(self.vers_expr)
+        sample_gen = self.vers_expr.sample(prj, self.rev_list)
+
+        self.assertEqual(next(sample_gen), "rev1")
+        with self.assertRaises(StopIteration):
+            next(sample_gen)
+        mock_get_tagged_revisions.assert_called()
+
+    @mock.patch('varats.utils.experiment_util.get_tagged_revisions')
+    def test_only_whitelisting_many(self, mock_get_tagged_revisions):
+        """
+        Test if we can whitelist file status
+        """
+        EU.CFG["versions"]["full"] = True
+        # Revision not in set
+        mock_get_tagged_revisions.return_value = [
+            ('rev1', FileStatusExtension.Success),
+            ('rev2', FileStatusExtension.Blocked),
+            ('rev3', FileStatusExtension.CompileError),
+            ('rev4', FileStatusExtension.Failed),
+            ('rev5', FileStatusExtension.Missing)
+        ]
+
+        EU.V_CFG["experiment"]["file_status_whitelist"] = [
+            'success', 'Failed', 'Missing'
+        ]
+
+        prj = EmptyProject(self.vers_expr)
+        sample_gen = self.vers_expr.sample(prj, self.rev_list)
+
+        self.assertEqual(next(sample_gen), "rev1")
+        self.assertEqual(next(sample_gen), "rev4")
+        self.assertEqual(next(sample_gen), "rev5")
+        with self.assertRaises(StopIteration):
+            next(sample_gen)
+        mock_get_tagged_revisions.assert_called()
+
+    @mock.patch('varats.utils.experiment_util.get_tagged_revisions')
+    def test_only_blacklisting_one(self, mock_get_tagged_revisions):
+        """
+        Test if we can whitelist file status
+        """
+        EU.CFG["versions"]["full"] = True
+        # Revision not in set
+        mock_get_tagged_revisions.return_value = [
+            ('rev1', FileStatusExtension.Success),
+            ('rev2', FileStatusExtension.Blocked),
+            ('rev3', FileStatusExtension.CompileError),
+            ('rev4', FileStatusExtension.Failed),
+            ('rev5', FileStatusExtension.Missing)
+        ]
+
+        EU.V_CFG["experiment"]["file_status_blacklist"] = ['success']
+
+        prj = EmptyProject(self.vers_expr)
+        sample_gen = self.vers_expr.sample(prj, self.rev_list)
+
+        self.assertEqual(next(sample_gen), "rev2")
+        self.assertEqual(next(sample_gen), "rev3")
+        self.assertEqual(next(sample_gen), "rev4")
+        self.assertEqual(next(sample_gen), "rev5")
+        with self.assertRaises(StopIteration):
+            next(sample_gen)
+        mock_get_tagged_revisions.assert_called()
+
+    @mock.patch('varats.utils.experiment_util.get_tagged_revisions')
+    def test_only_blacklisting_many(self, mock_get_tagged_revisions):
+        """
+        Test if we can whitelist file status
+        """
+        EU.CFG["versions"]["full"] = True
+        # Revision not in set
+        mock_get_tagged_revisions.return_value = [
+            ('rev1', FileStatusExtension.Success),
+            ('rev2', FileStatusExtension.Blocked),
+            ('rev3', FileStatusExtension.CompileError),
+            ('rev4', FileStatusExtension.Failed),
+            ('rev5', FileStatusExtension.Missing)
+        ]
+
+        EU.V_CFG["experiment"]["file_status_blacklist"] = [
+            'success', 'Failed', 'Blocked'
+        ]
+
+        prj = EmptyProject(self.vers_expr)
+        sample_gen = self.vers_expr.sample(prj, self.rev_list)
+
+        self.assertEqual(next(sample_gen), "rev3")
+        self.assertEqual(next(sample_gen), "rev5")
+        with self.assertRaises(StopIteration):
+            next(sample_gen)
+        mock_get_tagged_revisions.assert_called()
+
+    @mock.patch('varats.utils.experiment_util.get_tagged_revisions')
+    def test_white_overwrite_blacklisting(self, mock_get_tagged_revisions):
+        """
+        Test if we can whitelist file status
+        """
+        EU.CFG["versions"]["full"] = True
+        # Revision not in set
+        mock_get_tagged_revisions.return_value = [
+            ('rev1', FileStatusExtension.Success),
+            ('rev2', FileStatusExtension.Blocked),
+            ('rev3', FileStatusExtension.CompileError),
+            ('rev4', FileStatusExtension.Failed),
+            ('rev5', FileStatusExtension.Missing)
+        ]
+
+        EU.V_CFG["experiment"]["file_status_blacklist"] = ['Failed']
+        EU.V_CFG["experiment"]["file_status_whitelist"] = ['Failed']
+
+        prj = EmptyProject(self.vers_expr)
+        sample_gen = self.vers_expr.sample(prj, self.rev_list)
+
+        self.assertEqual(next(sample_gen), "rev4")
+        with self.assertRaises(StopIteration):
+            next(sample_gen)
+        mock_get_tagged_revisions.assert_called()

--- a/varats/data/report.py
+++ b/varats/data/report.py
@@ -68,6 +68,27 @@ class FileStatusExtension(Enum):
         regex_grp += "))"
         return regex_grp
 
+    @staticmethod
+    def get_file_status_from_str(status_name: str) -> 'FileStatusExtension':
+        """
+        Map names of file status to enum values.
+
+        Test:
+        >>> FileStatusExtension.get_file_status_from_str('success')
+        <FileStatusExtension.Success: ('success', <ANSIStyle: Green>)>
+
+        >>> FileStatusExtension.get_file_status_from_str('###')
+        <FileStatusExtension.Missing: ('###', <ANSIStyle: Full: Orange3>)>
+
+        >>> FileStatusExtension.get_file_status_from_str('CompileError')
+        <FileStatusExtension.CompileError: ('cerror', <ANSIStyle: Red>)>
+        """
+        for fs_enum in FileStatusExtension:
+            if status_name in (fs_enum.name, fs_enum.value[0]):
+                return fs_enum
+
+        raise ValueError('Unknown file status extension name')
+
 
 class MetaReport(type):
 

--- a/varats/settings.py
+++ b/varats/settings.py
@@ -82,8 +82,23 @@ CFG['db'] = {
 
 CFG['experiment'] = {
     "only_missing": {
-        "default": True,
-        "desc": "Only run missing version"
+        "default":
+        True,
+        "desc":
+        "Only run missing version [Deprecated]"
+        "This option is replaced by file_status_blacklist = [Success]"
+    },
+    "file_status_blacklist": {
+        "default": [],
+        "desc":
+        "Do not include revision with these file status for benchbuild "
+        "processing"
+    },
+    "file_status_whitelist": {
+        "default": [],
+        "desc":
+        "Only include revision with these file status for benchbuild "
+        "processing"
     },
     "random_order": {
         "default": False,

--- a/varats/settings.py
+++ b/varats/settings.py
@@ -89,7 +89,7 @@ CFG['experiment'] = {
         "This option is replaced by file_status_blacklist = [Success]"
     },
     "file_status_blacklist": {
-        "default": [Success, Blocked],
+        "default": ['Success', 'Blocked'],
         "desc":
         "Do not include revision with these file status for benchbuild "
         "processing"

--- a/varats/settings.py
+++ b/varats/settings.py
@@ -89,7 +89,7 @@ CFG['experiment'] = {
         "This option is replaced by file_status_blacklist = [Success]"
     },
     "file_status_blacklist": {
-        "default": [],
+        "default": [Success, Blocked],
         "desc":
         "Do not include revision with these file status for benchbuild "
         "processing"


### PR DESCRIPTION
FileStatus white/blacklisting is a replacement for `only_missing` to specify
which revision should be analyzed by benchbuild.