### PR TITLE
Fixes a performance regression in vara-cs status

### DIFF
--- a/varats/projects/c_projects/gravity.py
+++ b/varats/projects/c_projects/gravity.py
@@ -20,16 +20,16 @@ from varats.utils.project_util import (get_all_revisions_between,
                                        BlockedRevisionRange)
 
 
-@with_git(
-    "https://github.com/marcobambini/gravity.git",
-    refspec="HEAD",
-    shallow_clone=False,
-    version_filter=project_filter_generator("gravity"))
 @block_revisions([
     BlockedRevisionRange("0b8e0e047fc3d5e18ead3221ad54920f1ad0eedc",
                          "8f417752dd14deea64249b5d32b6138ebc877fa9",
                          "nothing to build")
 ])
+@with_git(
+    "https://github.com/marcobambini/gravity.git",
+    refspec="HEAD",
+    shallow_clone=False,
+    version_filter=project_filter_generator("gravity"))
 class Gravity(Project):  # type: ignore
     """ Programming language Gravity """
 

--- a/varats/utils/project_util.py
+++ b/varats/utils/project_util.py
@@ -157,6 +157,9 @@ def block_revisions(
     """
     Decorator for project classes for blacklisting/blocking revisions.
 
+    ATTENTION: This decorator depends on things introduced by the
+    @with_git decorator and therefore must be used above that decorator.
+
     This adds a new static method `is_blocked_revision` that checks
     whether a given revision id is marked as blocked.
 

--- a/varats/utils/project_util.py
+++ b/varats/utils/project_util.py
@@ -147,7 +147,8 @@ class BlockedRevisionRange():
             self.__id_start, self.__id_end)
 
     def __iter__(self) -> tp.Iterator[str]:
-        assert self.__revision_list is not None
+        if self.__revision_list is None:
+            raise AssertionError
         return self.__revision_list.__iter__()
 
 

--- a/varats/utils/project_util.py
+++ b/varats/utils/project_util.py
@@ -142,11 +142,12 @@ class BlockedRevisionRange():
         """
         return self.__reason
 
-    def init_cache(self):
+    def init_cache(self) -> None:
         self.__revision_list = get_all_revisions_between(
             self.__id_start, self.__id_end)
 
     def __iter__(self) -> tp.Iterator[str]:
+        assert self.__revision_list is not None
         return self.__revision_list.__iter__()
 
 


### PR DESCRIPTION
This PR fixes a performance regression in `vara-cs status` that occurred when using revision blocking. The regression was caused by unnecessary `cwd` commands. 
Resolves se-passau/VaRA#529