### PR TITLE
Implements configurable code churn

### DIFF
--- a/tests/utils/test_git_util.py
+++ b/tests/utils/test_git_util.py
@@ -1,0 +1,57 @@
+"""
+Test VaRA git utilities
+"""
+import typing as tp
+import unittest
+import unittest.mock as mock
+
+from varats.utils.git_util import ChurnConfig
+
+
+class TestChurnConfig(unittest.TestCase):
+    """
+    Test if ChurnConfig sets languages correctly.
+    """
+
+    def test_enable_language(self):
+        init_config = ChurnConfig.create_default_config()
+        self.assertFalse(init_config.is_enabled('c'))
+        init_config.enable_language(ChurnConfig.Language.CPP)
+        self.assertFalse(init_config.is_enabled('c'))
+        init_config.enable_language(ChurnConfig.Language.C)
+        self.assertTrue(init_config.is_enabled('c'))
+
+    def test_initial_config(self):
+        init_config = ChurnConfig.create_default_config()
+        self.assertTrue(init_config.include_everything)
+        self.assertListEqual(init_config.enabled_languages, [])
+
+    def test_c_language_config(self):
+        c_style_config = ChurnConfig.create_c_language_config()
+        self.assertTrue(c_style_config.is_enabled('h'))
+        self.assertTrue(c_style_config.is_enabled('c'))
+
+    def test_c_style_config(self):
+        c_style_config = ChurnConfig.create_c_style_languages_config()
+        self.assertTrue(c_style_config.is_enabled('h'))
+        self.assertTrue(c_style_config.is_enabled('c'))
+        self.assertTrue(c_style_config.is_enabled('hpp'))
+        self.assertTrue(c_style_config.is_enabled('cpp'))
+        self.assertTrue(c_style_config.is_enabled('hxx'))
+        self.assertTrue(c_style_config.is_enabled('cxx'))
+
+    def test_enabled_language(self):
+        c_config = ChurnConfig.create_c_language_config()
+        self.assertTrue(c_config.is_language_enabled(ChurnConfig.Language.C))
+        self.assertFalse(c_config.is_language_enabled(ChurnConfig.Language.CPP))
+
+    def test_extensions_repr_gen(self):
+        c_config = ChurnConfig.create_c_language_config()
+        self.assertEqual(c_config.get_extensions_repr(), "c, h")
+        self.assertEqual(c_config.get_extensions_repr("|"), "c|h")
+
+        c_style_config = ChurnConfig.create_c_style_languages_config()
+        self.assertEqual(c_style_config.get_extensions_repr(),
+                         "c, cpp, cxx, h, hpp, hxx")
+        self.assertEqual(c_style_config.get_extensions_repr("|"),
+                         "c|cpp|cxx|h|hpp|hxx")

--- a/tests/utils/test_git_util.py
+++ b/tests/utils/test_git_util.py
@@ -1,9 +1,7 @@
 """
 Test VaRA git utilities
 """
-import typing as tp
 import unittest
-import unittest.mock as mock
 
 from varats.utils.git_util import ChurnConfig
 

--- a/varats/plots/blame_lorenz_curve.py
+++ b/varats/plots/blame_lorenz_curve.py
@@ -23,7 +23,7 @@ from varats.data.reports.blame_report import (BlameReport,
 from varats.plots.repository_churn import (draw_code_churn,
                                            build_repo_churn_table)
 from varats.utils.project_util import get_local_project_git
-from varats.utils.git_util import calc_repo_code_churn
+from varats.utils.git_util import calc_repo_code_churn, ChurnConfig
 from varats.plots.plot import Plot
 
 
@@ -185,7 +185,10 @@ def filter_non_code_changes(blame_data: pd.DataFrame,
         filtered data frame without rows related to non code changes
     """
     repo = get_local_project_git(project_name)
-    code_related_changes = [x[:10] for x in calc_repo_code_churn(repo)]
+    code_related_changes = [
+        x[:10] for x in calc_repo_code_churn(
+            repo, ChurnConfig.create_c_style_languages_config())
+    ]
     return blame_data[blame_data.apply(
         lambda x: x['revision'][:10] in code_related_changes, axis=1)]
 

--- a/varats/plots/repository_churn.py
+++ b/varats/plots/repository_churn.py
@@ -14,7 +14,7 @@ from varats.data.reports.commit_report import CommitMap
 from varats.paper.case_study import CaseStudy
 from varats.plots.plot import Plot
 from varats.utils.project_util import get_local_project_git
-from varats.utils.git_util import calc_repo_code_churn
+from varats.utils.git_util import calc_repo_code_churn, ChurnConfig
 
 
 def build_repo_churn_table(project_name: str,
@@ -42,7 +42,9 @@ def build_repo_churn_table(project_name: str,
         return df_layout
 
     repo = get_local_project_git(project_name)
-    code_churn = calc_repo_code_churn(repo)
+    # By default we only look at c-style code files
+    code_churn = calc_repo_code_churn(
+        repo, ChurnConfig.create_c_style_languages_config())
     churn_data = pd.DataFrame({
         "revision": [x for x in code_churn],
         "rev_id": [commit_map.time_id(x) for x in code_churn],

--- a/varats/utils/git_util.py
+++ b/varats/utils/git_util.py
@@ -126,7 +126,7 @@ class ChurnConfig():
         """Disable `language` in the config."""
         self.__enabled_languages.remove(language)
 
-    def get_extensions_repr(self, sep=", ") -> str:
+    def get_extensions_repr(self, sep: str = ", ") -> str:
         """
         Returns a string that containts all file extensions from all enabled
         languages

--- a/varats/utils/git_util.py
+++ b/varats/utils/git_util.py
@@ -4,12 +4,148 @@ Utility module for handling git repos.
 
 import typing as tp
 import re
+from enum import Enum
 
 import pygit2
 from plumbum.cmd import git
 from plumbum import local
 
 from varats.utils.project_util import get_local_project_git
+
+
+class ChurnConfig():
+    """
+    The churn config allows the user to change how code churn is calculated.
+    Churn is by default calulcated considering all files in a repository.
+    Users can select a specific set of file extensions to only be considered
+    in the code churn, e.g., by selecting `h` and `c` only C related files
+    will be used to compute the code churn.
+    """
+
+    class Language(Enum):
+
+        C = {"h", "c"}
+        CPP = {"h", "hxx", "hpp", "cxx", "cpp"}
+
+    def __init__(self) -> None:
+        self.__enabled_languages: tp.List[ChurnConfig.Language] = []
+
+    @staticmethod
+    def create_default_config() -> 'ChurnConfig':
+        """
+        Create a default configuration that includes all files in the code
+        churn, e.g., enabling all languages/file extensions.
+        """
+        return ChurnConfig()
+
+    @staticmethod
+    def create_c_language_config() -> 'ChurnConfig':
+        """
+        Create a config that only allows C related files, e.g., headers and 
+        source files.
+        """
+        config = ChurnConfig()
+        config.enable_language(ChurnConfig.Language.C)
+        return config
+
+    @staticmethod
+    def create_c_style_languages_config() -> 'ChurnConfig':
+        """
+        Create a config that allows all files related to C-style
+        languages, i.e., C/CPP.
+        """
+        config = ChurnConfig.create_c_language_config()
+        config.enable_language(ChurnConfig.Language.CPP)
+        return config
+
+    @staticmethod
+    def init_as_default_if_none(config: tp.Optional['ChurnConfig']
+                               ) -> 'ChurnConfig':
+        """
+        Returns a default initialized config or the passed one.
+
+        Args:
+            config: possibly initialized config
+
+        Returns:
+            passed `config` or a default initialized one
+        """
+        if config is None:
+            return ChurnConfig.create_default_config()
+        return config
+
+    @property
+    def include_everything(self) -> bool:
+        """
+        Checks if all file extensions are valid.
+
+        Returns:
+            True, if no specific language is enabled
+        """
+        return not bool(self.__enabled_languages)
+
+    @property
+    def enabled_languages(self) -> tp.List['ChurnConfig.Language']:
+        """
+        Returns a list of specifically enabled languages.
+        """
+        return self.__enabled_languages
+
+    def is_enabled(self, file_extension: str) -> bool:
+        """
+        Checks if a file_extension is enabled.
+
+        Args:
+            file_extension: extension of a file, e.g., `h` for foo.h
+
+        Returns:
+            True, if the extension is currently enabled in the config
+        """
+        for lang in self.enabled_languages:
+            if file_extension in lang.value:
+                return True
+        return False
+
+    def is_language_enabled(self, language: 'ChurnConfig.Language') -> bool:
+        """
+        Checks if a language is enabled.
+
+        Args:
+            language: language to check
+
+        Returns:
+            True, if the language was enabled
+        """
+        return language in self.enabled_languages
+
+    def enable_language(self, language: 'ChurnConfig.Language') -> None:
+        """Enable `language` in the config."""
+        self.__enabled_languages.append(language)
+
+    def disable_language(self, language: 'ChurnConfig.Language') -> None:
+        """Disable `language` in the config."""
+        self.__enabled_languages.remove(language)
+
+    def get_extensions_repr(self, sep=", ") -> str:
+        """
+        Returns a string that containts all file extensions from all enabled
+        languages
+
+        Args:
+            sep: separator inserted between file extensions
+
+        Returns:
+            string representation of all enabled extension types
+        """
+        concat_str = ""
+        tmp_sep = ""
+        for ext in sorted(
+            {ext for lang in self.enabled_languages for ext in lang.value}):
+            concat_str += tmp_sep
+            tmp_sep = sep
+            concat_str += ext
+
+        return concat_str
 
 
 def create_commit_lookup_helper(project_name: str
@@ -59,6 +195,7 @@ GIT_LOG_MATCHER = re.compile(r"\'(?P<hash>.*)\'\n?" +
 
 
 def __calc_code_churn_range_impl(repo_path: str,
+                                 churn_config: ChurnConfig,
                                  start_range: tp.Optional[str] = None,
                                  end_range: tp.Optional[str] = None
                                 ) -> tp.Dict[str, tp.Tuple[int, int, int]]:
@@ -66,7 +203,13 @@ def __calc_code_churn_range_impl(repo_path: str,
     Calculates all churn values for the commits in the specified range [start..end]
     If no range is supplied, the churn values of all commits are calculated.
 
-    git log --pretty=format:'%H' --date=short --shortstat -- ':*.[c|h]'
+    git log --pretty=format:'%H' --date=short --shortstat -- ':*.[enabled_exts]'
+
+    Args:
+        repo_path: path to the git repository
+        churn_config: churn config to customize churn generation
+        start_range: begin churn calculation at start commit
+        end_range: end churn calculation at end commit
     """
 
     churn_values: tp.Dict[str, tp.Tuple[int, int, int]] = {}
@@ -82,9 +225,14 @@ def __calc_code_churn_range_impl(repo_path: str,
 
     with local.cwd(repo_path):
         base_params = [
-            "log", "--pretty=format:'%H'", "--date=short", "--shortstat", "-l0",
-            "--", ":*.[c|h]"
+            "log", "--pretty=format:'%H'", "--date=short", "--shortstat", "-l0"
         ]
+        if not churn_config.include_everything:
+            base_params.append("--")
+            # builds a regrex to select files that git includes into churn calc
+            base_params.append(":*.[" + churn_config.get_extensions_repr('|') +
+                               "]")
+
         if revision_range:
             stdout = git(base_params, revision_range)
         else:
@@ -100,20 +248,12 @@ def __calc_code_churn_range_impl(repo_path: str,
             deletions = int(deletions_m) if deletions_m is not None else 0
             churn_values[commit_hash] = (files_changed, insertions, deletions)
 
-    # Sadly, pygit2 currently gives us wrong/different diffs for renames, therefore,
-    # we have to fall back to calling git directly.
-    #
-    #for commit in repo.walk(repo.head.target, pygit2.GIT_SORT_TIME):
-    #    churn = calc_code_churn(repo, commit)
-    #    pred = commit.parents[0]
-    #    diff = repo.diff(pred, commit)
-    #    churn_values[commit.id] = (diff.stats.files_changed, diff.stats.insertions,
-    #                               diff.stats.deletions)
     return churn_values
 
 
 def calc_code_churn_range(
         repo: tp.Union[pygit2.Repository, str],
+        churn_config: tp.Optional[ChurnConfig] = None,
         start_range: tp.Optional[tp.Union[pygit2.Commit, str]] = None,
         end_range: tp.Optional[tp.Union[pygit2.Commit, str]] = None
 ) -> tp.Dict[str, tp.Tuple[int, int, int]]:
@@ -121,42 +261,69 @@ def calc_code_churn_range(
     Calculates all churn values for the commits in the specified range [start..end]
     If no range is supplied, the churn values of all commits are calculated.
 
-    For code churn, we only consider changes in source files.
+    Args:
+        repo: git repository
+        churn_config: churn config to customize churn generation
+
+    Returns:
+        dict of churn triples, where the commit hash points to
+        (files changed, insertions, deletions)
     """
+    churn_config = ChurnConfig.init_as_default_if_none(churn_config)
     return __calc_code_churn_range_impl(
         repo.path if isinstance(repo, pygit2.Repository) else repo,
-        start_range.id
+        churn_config, start_range.id
         if isinstance(start_range, pygit2.Commit) else start_range,
         end_range.id if isinstance(end_range, pygit2.Commit) else end_range)
 
 
 def calc_commit_code_churn(repo: pygit2.Repository,
-                           commit: pygit2.Commit) -> tp.Tuple[int, int, int]:
+                           commit: pygit2.Commit,
+                           churn_config: tp.Optional[ChurnConfig] = None
+                          ) -> tp.Tuple[int, int, int]:
     """
     Calculates churn of a specific commit.
 
-    For code churn, we only consider changes in source files.
+    Args:
+        repo: git repository
+        churn_config: churn config to customize churn generation
+
+    Returns:
+        dict of churn triples, where the commit hash points to
+        (files changed, insertions, deletions)
     """
-    return calc_code_churn_range(repo, commit, commit)[str(commit.id)]
+    churn_config = ChurnConfig.init_as_default_if_none(churn_config)
+    return calc_code_churn_range(repo, churn_config, commit,
+                                 commit)[str(commit.id)]
 
 
-def calc_repo_code_churn(repo: pygit2.Repository
+def calc_repo_code_churn(repo: pygit2.Repository,
+                         churn_config: tp.Optional[ChurnConfig] = None
                         ) -> tp.Dict[str, tp.Tuple[int, int, int]]:
     """
     Calculates code churn for a repository.
 
-    For code churn, we only consider changes in source files.
+    Args:
+        repo: git repository
+        churn_config: churn config to customize churn generation
+
+    Returns:
+        dict of churn triples, where the commit hash points to
+        (files changed, insertions, deletions)
     """
-    return calc_code_churn_range(repo)
+    churn_config = ChurnConfig.init_as_default_if_none(churn_config)
+    return calc_code_churn_range(repo, churn_config)
 
 
-def __print_calc_repo_code_churn(repo: pygit2.Repository) -> None:
+def __print_calc_repo_code_churn(repo: pygit2.Repository,
+                                 churn_config: tp.Optional[ChurnConfig] = None
+                                ) -> None:
     """
     Prints calc repo code churn data like git log would do.
-
-    git log --pretty=format:'%H' --date=short --shortstat -- ':*.[c|h]'
     """
-    churn_map = calc_repo_code_churn(repo)
+    churn_config = ChurnConfig.init_as_default_if_none(churn_config)
+    churn_map = calc_repo_code_churn(repo, churn_config)
+
     for commit in repo.walk(repo.head.target, pygit2.GIT_SORT_TIME):
         commit_hash = str(commit.id)
         print(commit_hash)

--- a/varats/utils/git_util.py
+++ b/varats/utils/git_util.py
@@ -77,7 +77,7 @@ class ChurnConfig():
     @property
     def include_everything(self) -> bool:
         """
-        Checks if all file extensions are valid.
+        Checks if all files should be considered in the code churn.
 
         Returns:
             True, if no specific language is enabled

--- a/varats/utils/git_util.py
+++ b/varats/utils/git_util.py
@@ -41,7 +41,7 @@ class ChurnConfig():
     @staticmethod
     def create_c_language_config() -> 'ChurnConfig':
         """
-        Create a config that only allows C related files, e.g., headers and 
+        Create a config that only allows C related files, e.g., headers and
         source files.
         """
         config = ChurnConfig()


### PR DESCRIPTION
The code churn api now allows the user to pass a config object that
specifies which files should be included in the churn calculation.
ChurnConfig provides a default and different generator functions for
often used languages.

resolves se-passau/VaRA#556