### PR TITLE
VaRA now also needs libxml2 for loading FeatureModels

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ sudo apt install python3-venv # If you want to install VaRA-TS in a python virtu
 
 Additional packages are required to build VaRA from source.
 ```bash
-sudo apt install libsqlite3-dev libcurl4-openssl-dev libboost-all-dev libpapi-dev googletest
+sudo apt install libsqlite3-dev libcurl4-openssl-dev libboost-all-dev libpapi-dev googletest libxml2-dev
 ```
 
 ### Install VaRA-TS


### PR DESCRIPTION
Adapts the required dependencies for VaRA, needed after we merge se-passau/VaRA#577.