### PR TITLE
Blocks sphinx upgrade to version 3.0.0

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
-Sphinx>=2.3.1
+Sphinx>=2.3.1,<3.0.0
 sphinxcontrib-programoutput>=0.14
 sphinx-autodoc-typehints>=1.10


### PR DESCRIPTION
Currently one of our extensions does not support sphinx 3.0.0 due to a
deprecated API being removed.

This will be resolved with agronholm/sphinx-autodoc-typehints#133