### PR TITLE
Implements block revision filter for case study generation

### DIFF
--- a/tests/data/test_revisions.py
+++ b/tests/data/test_revisions.py
@@ -1,0 +1,63 @@
+"""Test revision helper functions."""
+
+import unittest
+import unittest.mock as mock
+
+from varats.data.revisions import filter_blocked_revisions
+from varats.projects.c_projects.glibc import Glibc
+from varats.projects.c_projects.gravity import Gravity
+
+
+class TestFilterBlockedRevisions(unittest.TestCase):
+    """Test if the revision filter function correctly filters revision lists."""
+
+    def setUp(self) -> None:
+        gravity_patcher = mock.patch(
+            'varats.projects.c_projects.gravity.Gravity', spec=Gravity
+        )
+        self.addCleanup(gravity_patcher.stop)
+        self.mock_gravity = gravity_patcher.start()
+        self.blocked_revision = ['e207f0cc87', '109a1e6233']
+        self.mock_gravity.is_blocked_revision = lambda x: (
+            x in self.blocked_revision, ""
+        )
+
+    def test_filter_empty_list(self):
+        self.assertListEqual([], filter_blocked_revisions([],
+                                                          self.mock_gravity))
+
+    def test_filter_list_without_blocked(self):
+        """Checks if we do not filter unblocked revisions."""
+        unblocked_revisions = [
+            '8bece6fd0c', 'fcfadde2a5', 'd6306bc0d5', '2dc8bdd988', 'a6158db8bb'
+        ]
+
+        filtered_revisions = filter_blocked_revisions(
+            unblocked_revisions, self.mock_gravity
+        )
+
+        self.assertLessEqual(unblocked_revisions, filtered_revisions)
+
+    def test_filter_list_with_blocked(self):
+        """Checks if we filter blocked revisions."""
+        unblocked_revisions = [
+            '8bece6fd0c', 'fcfadde2a5', 'd6306bc0d5', '2dc8bdd988', 'a6158db8bb'
+        ]
+        blocked_revision = ['e207f0cc87', '109a1e6233']
+
+        filtered_revisions = filter_blocked_revisions(
+            unblocked_revisions + blocked_revision, self.mock_gravity
+        )
+
+        self.assertLessEqual(unblocked_revisions, filtered_revisions)
+
+    def test_filter_list_of_non_blocked_project(self):
+        """Checks if the filter works on projects that don't have blocked
+        revisions."""
+        unblocked_revisions = ['61416e1921', '16536e98e3']
+
+        filtered_revisions = filter_blocked_revisions(
+            unblocked_revisions, Glibc
+        )
+
+        self.assertLessEqual(unblocked_revisions, filtered_revisions)

--- a/varats/data/revisions.py
+++ b/varats/data/revisions.py
@@ -18,6 +18,40 @@ from varats.settings import CFG
 from varats.utils.project_util import get_project_cls_by_name
 
 
+def is_revision_blocked(revision: str, project_cls: tp.Type[Project]) -> bool:
+    """
+    Checks if a revision is blocked on a given project.
+
+    Args:
+        revision: the revision
+        project_cls: the project class the revision belongs to
+
+    Returns:
+        filtered revision list
+    """
+    if hasattr(project_cls, "is_blocked_revision"):
+        return tp.cast(bool, project_cls.is_blocked_revision(revision)[0])
+    return False
+
+
+def filter_blocked_revisions(
+    revisions: tp.List[str], project_cls: tp.Type[Project]
+) -> tp.List[str]:
+    """
+    Filter out all blocked revisions.
+
+    Args:
+        revisions: list of revisions
+        project_cls: the project class the revisions belong to
+
+    Returns:
+        filtered revision list
+    """
+    return [
+        rev for rev in revisions if not is_revision_blocked(rev, project_cls)
+    ]
+
+
 def __get_result_files_dict(
     project_name: str, result_file_type: MetaReport
 ) -> tp.Dict[str, tp.List[Path]]:
@@ -281,9 +315,7 @@ def __get_tag_for_revision(
     Returns:
         the status for the revision
     """
-    if tag_blocked and hasattr(
-        project_cls, "is_blocked_revision"
-    ) and project_cls.is_blocked_revision(revision)[0]:
+    if tag_blocked and is_revision_blocked(revision, project_cls):
         return FileStatusExtension.Blocked
 
     newest_res_file = max(file_list, key=lambda x: x.stat().st_mtime)

--- a/varats/paper/case_study.py
+++ b/varats/paper/case_study.py
@@ -23,6 +23,8 @@ from varats.data.revisions import (
     get_processed_revisions,
     get_tagged_revision,
     get_tagged_revisions,
+    filter_blocked_revisions,
+    is_revision_blocked,
 )
 from varats.data.version_header import VersionHeader
 from varats.plots.plot_utils import check_required_args
@@ -898,6 +900,10 @@ def extend_with_revs_per_year(
 
         for commit_index in sample_commit_indices:
             commit_hash = commits_in_year[commit_index]
+            if kwargs["ignore_blocked"] and is_revision_blocked(
+                commit_hash, get_project_cls_by_name(case_study.project_name)
+            ):
+                continue
             time_id = cmap.time_id(commit_hash)
             new_rev_items.append((commit_hash, time_id))
 
@@ -924,13 +930,20 @@ def extend_with_distrib_sampling(
         case_study: to extend
         cmap: commit map to map revisions to unique IDs
     """
+    is_blocked: tp.Callable[[str, tp.Type[tp.Any]], bool] = lambda rev, _: False
+    if kwargs["ignore_blocked"]:
+        is_blocked = is_revision_blocked
+
     # Needs to be sorted so the propability distribution over the length
     # of the list is the same as the distribution over the commits age history
     revision_list = [
         rev_item
         for rev_item in sorted(list(cmap.mapping_items()), key=lambda x: x[1])
         if not case_study.
-        has_revision_in_stage(rev_item[0], kwargs['merge_stage'])
+        has_revision_in_stage(rev_item[0], kwargs['merge_stage']) and
+        not is_blocked(
+            rev_item[0], get_project_cls_by_name(case_study.project_name)
+        )
     ]
 
     distribution_function = kwargs['distribution'].gen_distribution_function()
@@ -996,6 +1009,14 @@ def extend_with_smooth_revs(
     print("Using boundary gradient: ", boundary_gradient)
     new_revisions = plot.calc_missing_revisions(boundary_gradient)
 
+    if kwargs["ignore_blocked"]:
+        new_revisions = set(
+            filter_blocked_revisions(
+                list(new_revisions),
+                get_project_cls_by_name(case_study.project_name)
+            )
+        )
+
     # Remove revision that are already present in another stage.
     new_revisions = {
         rev for rev in new_revisions if not case_study.has_revision(rev)
@@ -1026,12 +1047,18 @@ def extend_with_release_revs(
         case_study: to extend
         cmap: commit map to map revisions to unique IDs
     """
-    project: tp.Type[Project] = get_project_cls_by_name(kwargs['project'])
-    release_provider = ReleaseProvider.get_provider_for_project(project)
+    project_cls: tp.Type[Project] = get_project_cls_by_name(kwargs['project'])
+    release_provider = ReleaseProvider.get_provider_for_project(project_cls)
     release_revisions: tp.List[str] = [
         revision for revision, release in
         release_provider.get_release_revisions(kwargs['release_type'])
     ]
+
+    if kwargs["ignore_blocked"]:
+        release_revisions = filter_blocked_revisions(
+            release_revisions, project_cls
+        )
+
     case_study.include_revisions([
         (rev, cmap.time_id(rev)) for rev in release_revisions
     ],

--- a/varats/paper/case_study.py
+++ b/varats/paper/case_study.py
@@ -892,6 +892,7 @@ def extend_with_revs_per_year(
         commits[commit_date.year].append(str(commit.id))
 
     new_rev_items = []  # new revisions that get added to to case_study
+    project_cls = get_project_cls_by_name(case_study.project_name)
     for year, commits_in_year in commits.items():
         samples = min(len(commits_in_year), kwargs['revs_per_year'])
         sample_commit_indices = sorted(
@@ -901,7 +902,7 @@ def extend_with_revs_per_year(
         for commit_index in sample_commit_indices:
             commit_hash = commits_in_year[commit_index]
             if kwargs["ignore_blocked"] and is_revision_blocked(
-                commit_hash, get_project_cls_by_name(case_study.project_name)
+                commit_hash, project_cls
             ):
                 continue
             time_id = cmap.time_id(commit_hash)
@@ -936,14 +937,13 @@ def extend_with_distrib_sampling(
 
     # Needs to be sorted so the propability distribution over the length
     # of the list is the same as the distribution over the commits age history
+    project_cls = get_project_cls_by_name(case_study.project_name)
     revision_list = [
         rev_item
         for rev_item in sorted(list(cmap.mapping_items()), key=lambda x: x[1])
         if not case_study.
         has_revision_in_stage(rev_item[0], kwargs['merge_stage']) and
-        not is_blocked(
-            rev_item[0], get_project_cls_by_name(case_study.project_name)
-        )
+        not is_blocked(rev_item[0], project_cls)
     ]
 
     distribution_function = kwargs['distribution'].gen_distribution_function()

--- a/varats/tools/driver_casestudy.py
+++ b/varats/tools/driver_casestudy.py
@@ -161,6 +161,12 @@ def __add_common_args(sub_parser: ArgumentParser) -> None:
         default=10,
         help="Number of revisions to select."
     )
+    sub_parser.add_argument(
+        "--ignore-blocked",
+        action="store_true",
+        default=False,
+        help="Ignore revisions that are marked as blocked."
+    )
 
 
 def __create_gen_parser(sub_parsers: _SubParsersAction) -> None:


### PR DESCRIPTION
Adds a new flag to vara-cs, which allows the user to specify to ignore
blocked revisions when sampling revisions for a case study.