### PR TITLE
Always use benchbuild.utils.cmd instead of plumbum.cmd

### DIFF
--- a/docs/source/vara-ts-api/tools/vara-art.rst
+++ b/docs/source/vara-ts-api/tools/vara-art.rst
@@ -5,6 +5,7 @@ This tool manages the :ref:`Artefacts<Module: artefacts>` of a
 :ref:`paper config<How to use paper configs>`.
 
 .. program-output:: vara-art -h
+    :nostderr:
 
 The subcommand ``vara-art add`` adds a new artefact to the current paper config.
 

--- a/docs/source/vara-ts-api/tools/vara-art.rst
+++ b/docs/source/vara-ts-api/tools/vara-art.rst
@@ -5,7 +5,6 @@ This tool manages the :ref:`Artefacts<Module: artefacts>` of a
 :ref:`paper config<How to use paper configs>`.
 
 .. program-output:: vara-art -h
-    :nostderr:
 
 The subcommand ``vara-art add`` adds a new artefact to the current paper config.
 

--- a/varats/data/provider/cve/cve_map.py
+++ b/varats/data/provider/cve/cve_map.py
@@ -31,10 +31,10 @@ import typing as tp
 from collections import defaultdict
 from pathlib import Path
 
+from benchbuild.utils.cmd import git
 from packaging.version import LegacyVersion, Version
 from packaging.version import parse as parse_version
 from plumbum import local
-from plumbum.cmd import git
 
 from varats.data.provider.cve.cve import (
     CVE,

--- a/varats/tools/commit_map.py
+++ b/varats/tools/commit_map.py
@@ -3,8 +3,8 @@
 import typing as tp
 from pathlib import Path
 
+from benchbuild.utils.cmd import git, mkdir
 from plumbum import local
-from plumbum.cmd import git, mkdir
 
 from varats.data.reports.commit_report import CommitMap
 from varats.utils.project_util import get_local_project_git_path

--- a/varats/tools/research_tools/vara.py
+++ b/varats/tools/research_tools/vara.py
@@ -6,8 +6,8 @@ import shutil
 import typing as tp
 from pathlib import Path
 
+from benchbuild.utils.cmd import ln, mkdir
 from plumbum import local
-from plumbum.cmd import ln, mkdir
 from PyQt5.QtCore import QProcess
 
 from varats.plots.plot_utils import check_required_args

--- a/varats/utils/git_util.py
+++ b/varats/utils/git_util.py
@@ -5,8 +5,8 @@ import typing as tp
 from enum import Enum
 
 import pygit2
+from benchbuild.utils.cmd import git
 from plumbum import local
-from plumbum.cmd import git
 
 from varats.utils.project_util import get_local_project_git
 

--- a/varats/vara_manager.py
+++ b/varats/vara_manager.py
@@ -16,8 +16,8 @@ from enum import Enum
 from pathlib import Path
 from threading import RLock
 
+from benchbuild.utils.cmd import cmake, git, grep, ln, mkdir
 from plumbum import RETCODE, TF, local
-from plumbum.cmd import cmake, git, grep, ln, mkdir
 from PyQt5.QtCore import (
     QObject,
     QProcess,


### PR DESCRIPTION
The benchbuild version of the `cmd` module does not throw `ImportError`s but logs such errors instead.

Resolves se-passau/VaRA#654