### PR TITLE
Changes build folder symlink to a relative path

### DIFF
--- a/varats/tools/research_tools/vara.py
+++ b/varats/tools/research_tools/vara.py
@@ -70,7 +70,7 @@ class VaRACodeBase(CodeBase):
         ).path
         mkdir(llvm_project_dir / "build/")
         with local.cwd(llvm_project_dir / "build/"):
-            ln("-s", llvm_project_dir / "vara/utils/vara/builds/", "build_cfg")
+            ln("-s", "../vara/utils/vara/builds/", "build_cfg")
 
     def checkout_vara_version(
         self, version: int, use_dev_branches: bool


### PR DESCRIPTION
A relative path is better here because we depend less on system
specific parts and only describe inter relationships between project
folders.