### PR TITLE
Replaces broken python resource ulimit with prlimit wrapper call

### DIFF
--- a/varats/experiments/phasar/ide_linear_constant_experiment.py
+++ b/varats/experiments/phasar/ide_linear_constant_experiment.py
@@ -14,8 +14,8 @@ from varats.experiments.wllvm import Extract, RunWLLVM
 from varats.settings import bb_cfg
 from varats.utils.experiment_util import (
     PEErrorHandler,
-    UnlimitStackSize,
     VersionExperiment,
+    wrap_unlimit_stack_size,
     get_default_compile_error_wrapped,
     exec_func_with_pe_error_handler,
 )
@@ -81,6 +81,8 @@ class IDELinearConstantAnalysis(actions.Step):  # type: ignore
             run_cmd = (
                 phasar[phasar_params] > f'{varats_result_folder}/{result_file}'
             )
+
+            run_cmd = wrap_unlimit_stack_size(run_cmd)
 
             exec_func_with_pe_error_handler(
                 run_cmd,
@@ -166,7 +168,6 @@ class IDELinearConstantAnalysisExperiment(VersionExperiment):
             analysis_actions.append(actions.Compile(project))
             analysis_actions.append(Extract(project, handler=error_handler))
 
-        analysis_actions.append(UnlimitStackSize(project))
         analysis_actions.append(IDELinearConstantAnalysis(project))
         analysis_actions.append(actions.Clean(project))
 

--- a/varats/experiments/vara/blame_report_experiment.py
+++ b/varats/experiments/vara/blame_report_experiment.py
@@ -21,7 +21,7 @@ from varats.utils.experiment_util import (
     exec_func_with_pe_error_handler,
     VersionExperiment,
     PEErrorHandler,
-    UnlimitStackSize,
+    wrap_unlimit_stack_size,
 )
 
 
@@ -80,6 +80,7 @@ class BlameReportGeneration(actions.Step):  # type: ignore
 
             opt_params = [
                 "-vara-BD", "-vara-BR", "-vara-init-commits",
+                "-vara-use-phasar",
                 f"-vara-report-outfile={vara_result_folder}/{result_file}",
                 bc_cache_folder / Extract.get_bc_file_name(
                     project_name=project.name,
@@ -89,6 +90,8 @@ class BlameReportGeneration(actions.Step):  # type: ignore
             ]
 
             run_cmd = opt[opt_params]
+
+            run_cmd = wrap_unlimit_stack_size(run_cmd)
 
             timeout_duration = '8h'
             from benchbuild.utils.cmd import timeout
@@ -149,7 +152,6 @@ class BlameReportExperiment(VersionExperiment):
             project, extraction_error_handler=error_handler
         )
 
-        analysis_actions.append(UnlimitStackSize(project))
         analysis_actions.append(BlameReportGeneration(project))
         analysis_actions.append(actions.Clean(project))
 

--- a/varats/experiments/vara/phasar_env_analysis.py
+++ b/varats/experiments/vara/phasar_env_analysis.py
@@ -25,7 +25,7 @@ from varats.settings import bb_cfg
 from varats.utils.experiment_util import (
     FunctionPEErrorWrapper,
     PEErrorHandler,
-    UnlimitStackSize,
+    wrap_unlimit_stack_size,
     exec_func_with_pe_error_handler,
 )
 
@@ -107,6 +107,8 @@ class PhasarEnvIFDS(actions.Step):  # type: ignore
                 "{res_folder}/{res_file}".
                 format(res_folder=result_folder, res_file=result_file)]
 
+            phasar_run_cmd = wrap_unlimit_stack_size(phasar_run_cmd)
+
             # Run the phasar command with custom error handler and timeout
             exec_func_with_pe_error_handler(
                 timeout[timeout_duration, phasar_run_cmd],
@@ -176,7 +178,6 @@ class PhasarEnvironmentTracing(Experiment):  # type: ignore
                 analysis_actions.append(Extract(project))
                 break
 
-        analysis_actions.append(UnlimitStackSize(project))
         analysis_actions.append(PhasarEnvIFDS(project))
         analysis_actions.append(actions.Clean(project))
 

--- a/varats/utils/experiment_util.py
+++ b/varats/utils/experiment_util.py
@@ -138,9 +138,7 @@ def get_default_compile_error_wrapped(
     )
 
 
-def wrap_unlimit_stack_size(
-    cmd: tp.Callable[..., tp.Any]
-) -> tp.Callable[..., tp.Any]:
+def wrap_unlimit_stack_size(cmd: tp.Callable[..., tp.Any]) -> tp.Any:
     """
     Wraps a command with prlimit to be executed with max stack size, i.e.,
     setting the soft limit to the hard limit.
@@ -150,7 +148,8 @@ def wrap_unlimit_stack_size(
 
     Returns: wrapped command
     """
-    return prlimit["--stack=17179869184:", cmd]
+    max_stacksize_16gb = 17179869184
+    return prlimit[f"--stack=:{max_stacksize_16gb}", cmd]
 
 
 class VersionExperiment(Experiment):  # type: ignore

--- a/varats/utils/experiment_util.py
+++ b/varats/utils/experiment_util.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from benchbuild.experiment import Experiment
 from benchbuild.project import Project
 from benchbuild.utils.actions import Step, StepResult
+from benchbuild.utils.cmd import prlimit
 from plumbum.commands import ProcessExecutionError
 
 from varats.data.report import BaseReport, FileStatusExtension
@@ -137,23 +138,19 @@ def get_default_compile_error_wrapped(
     )
 
 
-class UnlimitStackSize(Step):  # type: ignore
+def wrap_unlimit_stack_size(
+    cmd: tp.Callable[..., tp.Any]
+) -> tp.Callable[..., tp.Any]:
     """
-    Set higher user limits on stack size for RAM intense experiments.
+    Wraps a command with prlimit to be executed with max stack size, i.e.,
+    setting the soft limit to the hard limit.
 
-    Basically the same as calling the shell built-in ulimit.
+    Args:
+        cmd: command that should be executed with max stack size
+
+    Returns: wrapped command
     """
-
-    NAME = "Unlimit stack size"
-    DESCRIPTION = "Sets new resource limits."
-
-    def __init__(self, project: Project):
-        super(UnlimitStackSize,
-              self).__init__(obj=project, action_fn=self.__call__)
-
-    def __call__(self) -> StepResult:
-        """Same as 'ulimit -s 16777216' in a shell."""
-        resource.setrlimit(resource.RLIMIT_STACK, (16777216, 16777216))
+    return prlimit["--stack=17179869184:", cmd]
 
 
 class VersionExperiment(Experiment):  # type: ignore

--- a/varats/utils/experiment_util.py
+++ b/varats/utils/experiment_util.py
@@ -149,7 +149,7 @@ def wrap_unlimit_stack_size(cmd: tp.Callable[..., tp.Any]) -> tp.Any:
     Returns: wrapped command
     """
     max_stacksize_16gb = 17179869184
-    return prlimit[f"--stack=:{max_stacksize_16gb}", cmd]
+    return prlimit[f"--stack={max_stacksize_16gb}:", cmd]
 
 
 class VersionExperiment(Experiment):  # type: ignore


### PR DESCRIPTION
Python resource is not able to correctly set the max stacksize in our
cluster environment, therefore, we replace it by a prlimit call to
execute commands with max stack size.