### PR TITLE
Configures sphinx-autodoc to detect testing modules

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -6,21 +6,21 @@
 
 # -- Path setup --------------------------------------------------------------
 
+import logging
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
-
-# pylint: skip-file
-
-import logging
+import os
+import sys
 
 import benchbuild.utils
 # -- Project information -----------------------------------------------------
 from pkg_resources import DistributionNotFound, get_distribution
+
+sys.path.insert(0, os.path.abspath('../../'))
+
+# pylint: skip-file
 
 try:
     __version__ = get_distribution("varats").version


### PR DESCRIPTION
Adds the repository base folder to the python `sys.path`, so autodoc can detect testing modules defined in `tests/`.