### PR TITLE
Replaces mock backport with unittest.mock

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,5 +1,5 @@
 [settings]
-known_third_party = PyQt5,argparse_utils,attr,benchbuild,github,matplotlib,mock,numpy,packaging,pandas,pkg_resources,plumbum,pygit2,pygtrie,pytest,requests,requests_cache,rich,scipy,seaborn,setuptools,sklearn,tabulate,test_case_study,yaml
+known_third_party = PyQt5,argparse_utils,attr,benchbuild,github,matplotlib,numpy,packaging,pandas,pkg_resources,plumbum,pygit2,pygtrie,pytest,requests,requests_cache,rich,scipy,seaborn,setuptools,sklearn,tabulate,test_case_study,yaml
 multi_line_output=3
 use_parentheses = True
 include_trailing_comma: True

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ argparse-utils>=1.2.0
 benchbuild>=5.2
 jupyter>=1.0.0
 matplotlib>=3.1.2
-mock>=2.0.0
 packaging>=20.1
 pandas>=0.22.0
 plumbum>=1.6.6

--- a/tests/paper/test_paper_config_manager.py
+++ b/tests/paper/test_paper_config_manager.py
@@ -2,11 +2,11 @@
 
 import typing as tp
 import unittest
+import unittest.mock as mock
 from collections import defaultdict
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 
-import mock
 from benchbuild.source import nosource
 from benchbuild.utils.revision_ranges import block_revisions, SingleRevision
 from test_case_study import YAML_CASE_STUDY

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -1,7 +1,6 @@
 """Test example file that can be used as orientation."""
 import unittest
-
-import mock
+import unittest.mock as mock
 
 
 class ExampleTestCase(unittest.TestCase):

--- a/tests/utils/test_cli_util.py
+++ b/tests/utils/test_cli_util.py
@@ -2,9 +2,8 @@
 
 import tempfile
 import unittest
+import unittest.mock as mock
 from pathlib import Path
-
-import mock
 
 from tests.test_utils import replace_config
 from varats.tools.research_tools.phasar import Phasar


### PR DESCRIPTION
From python3.4 onward unittest includes mock.