### PR TITLE
Fix missing bc_file_extensions for blame report experiments 

### DIFF
--- a/varats/varats/experiments/vara/blame_report_experiment.py
+++ b/varats/varats/experiments/vara/blame_report_experiment.py
@@ -78,7 +78,8 @@ class BlameReportGeneration(actions.Step):  # type: ignore
                 "-vara-use-phasar",
                 f"-vara-report-outfile={vara_result_folder}/{result_file}",
                 get_cached_bc_file_path(
-                    project, binary, [BCFileExtensions.NO_OPT]
+                    project, binary,
+                    [BCFileExtensions.NO_OPT, BCFileExtensions.TBAA]
                 )
             ]
 


### PR DESCRIPTION
Fixes wrong path in get_cached_bc_file_path by adding the TBAA bc_file_extension to the cached name. Currently needed in blame reports.