### PR TITLE
Update BenchBuild documentation

### DIFF
--- a/docs/source/vara-ts/benchbuild.rst
+++ b/docs/source/vara-ts/benchbuild.rst
@@ -25,7 +25,7 @@ The generated result files are place in the ``vara/results/$PROJECT_NAME`` folde
 
 Running BenchBuild outside the ``$VARA_ROOT/benchbuild`` directory
 ------------------------------------
-To execute BenchBuild from another directory the ``VARA_ROOT`` environment variable must be set. 
+To execute BenchBuild from another directory the ``VARA_ROOT`` environment variable must be set, so varats and benchbuild can locate the varats configuration file. 
 
 .. code-block:: bash
 

--- a/docs/source/vara-ts/benchbuild.rst
+++ b/docs/source/vara-ts/benchbuild.rst
@@ -23,6 +23,14 @@ Second, we change into the benchbuild folder and run an experiment that generate
 
 The generated result files are place in the ``vara/results/$PROJECT_NAME`` folder and can be further visualized with VaRA-TS graph generators.
 
+Running BenchBuild outside the ``$VARA_ROOT/benchbuild`` directory
+------------------------------------
+To execute BenchBuild from another directory the ``VARA_ROOT`` environment variable must be set. 
+
+.. code-block:: bash
+
+  export VARA_ROOT=/path/to/your/vara/root/directory
+
 How-to configure BenchBuild yourself
 ------------------------------------
 BenchBuild's configuration file ``.benchbuild.yml`` normally is placed inside the ``benchbuild`` folder, which is located in the vara root folder.

--- a/docs/source/vara-ts/benchbuild.rst
+++ b/docs/source/vara-ts/benchbuild.rst
@@ -25,14 +25,14 @@ The generated result files are place in the ``vara/results/$PROJECT_NAME`` folde
 
 Running BenchBuild outside the ``$VARA_ROOT/benchbuild`` directory
 ------------------------------------
-To execute BenchBuild from another directory the ``VARA_ROOT`` environment variable must be set, so varats and benchbuild can locate the varats configuration file. 
+To execute BenchBuild from another directory the ``VARA_ROOT`` environment variable must be set, so varats and benchbuild can locate the varats configuration file.
 
 .. code-block:: bash
 
   # temporary:
   export VARA_ROOT=/path/to/your/vara/root/directory
-  # permanent: 
-  echo 'export VARA_ROOT=/path/to/your/vara/root/directory' >> ~/.$(basename $0)rc 
+  # permanent:
+  echo 'export VARA_ROOT=/path/to/your/vara/root/directory' >> ~/.$(basename $0)rc
 
 How-to configure BenchBuild yourself
 ------------------------------------

--- a/docs/source/vara-ts/benchbuild.rst
+++ b/docs/source/vara-ts/benchbuild.rst
@@ -29,7 +29,10 @@ To execute BenchBuild from another directory the ``VARA_ROOT`` environment varia
 
 .. code-block:: bash
 
+  # temporary:
   export VARA_ROOT=/path/to/your/vara/root/directory
+  # permanent: 
+  echo 'export VARA_ROOT=/path/to/your/vara/root/directory' >> ~/.$(basename $0)rc 
 
 How-to configure BenchBuild yourself
 ------------------------------------


### PR DESCRIPTION
Add a short section to the BenchBuild documentation on how to run BenchBuild outside the ``$VARA_ROOT/benchbuild`` directory.

Do you think the directory dummy is confusing?
`VARA_ROOT=/path/to/your/vara/root/directory`
