### PR TITLE
Adds save function for NoOpt plots

### DIFF
--- a/varats/varats/plots/blame_verifier_report_plots.py
+++ b/varats/varats/plots/blame_verifier_report_plots.py
@@ -248,32 +248,6 @@ class BlameVerifierReportPlot(Plot):
     def calc_missing_revisions(self, boundary_gradient: float) -> tp.Set[str]:
         pass
 
-
-class BlameVerifierReportNoOptPlot(BlameVerifierReportPlot):
-    """Plotting the successful and failed annotations of reports without
-    optimization."""
-    NAME = 'b_verifier_report_no_opt_plot'
-
-    def __init__(self, **kwargs: tp.Any) -> None:
-        super().__init__(self.NAME, **kwargs)
-
-    def plot(self, view_mode: bool) -> None:
-        legend_title: str
-
-        if _is_multi_cs_plot():
-            legend_title = "Success rate of projects:"
-        else:
-            legend_title = "Annotation types:"
-
-        extra_plot_cfg = {
-            'fig_title': 'Annotated project revisions with optimization',
-            'legend_title': legend_title
-        }
-        _verifier_plot(
-            opt_level=OptLevel.NO_OPT,
-            extra_plot_cfg=extra_plot_cfg,
-        )
-
     def save(
         self, path: tp.Optional[Path] = None, filetype: str = 'svg'
     ) -> None:
@@ -299,6 +273,32 @@ class BlameVerifierReportNoOptPlot(BlameVerifierReportPlot):
             bbox_inches='tight'
         )
         plt.close()
+
+
+class BlameVerifierReportNoOptPlot(BlameVerifierReportPlot):
+    """Plotting the successful and failed annotations of reports without
+    optimization."""
+    NAME = 'b_verifier_report_no_opt_plot'
+
+    def __init__(self, **kwargs: tp.Any) -> None:
+        super().__init__(self.NAME, **kwargs)
+
+    def plot(self, view_mode: bool) -> None:
+        legend_title: str
+
+        if _is_multi_cs_plot():
+            legend_title = "Success rate of projects:"
+        else:
+            legend_title = "Annotation types:"
+
+        extra_plot_cfg = {
+            'fig_title': 'Annotated project revisions without optimization',
+            'legend_title': legend_title
+        }
+        _verifier_plot(
+            opt_level=OptLevel.NO_OPT,
+            extra_plot_cfg=extra_plot_cfg,
+        )
 
 
 class BlameVerifierReportOptPlot(BlameVerifierReportPlot):
@@ -325,29 +325,3 @@ class BlameVerifierReportOptPlot(BlameVerifierReportPlot):
             opt_level=OptLevel.OPT,
             extra_plot_cfg=extra_plot_cfg,
         )
-
-    def save(
-        self, path: tp.Optional[Path] = None, filetype: str = 'svg'
-    ) -> None:
-        """
-        Save the current plot to a file.
-
-        Args:
-            path: The path where the file is stored (excluding the file name).
-            filetype: The file type of the plot.
-        """
-        self.plot(False)
-
-        if path is None:
-            plot_dir = Path(self.plot_kwargs["plot_dir"])
-        else:
-            plot_dir = path
-
-        # TODO (se-passau/VaRA#545): refactor dpi into plot_config. see.
-        plt.savefig(
-            plot_dir / f"{self.name}.{filetype}",
-            dpi=1200,
-            format=filetype,
-            bbox_inches='tight'
-        )
-        plt.close()

--- a/varats/varats/plots/blame_verifier_report_plots.py
+++ b/varats/varats/plots/blame_verifier_report_plots.py
@@ -274,6 +274,32 @@ class BlameVerifierReportNoOptPlot(BlameVerifierReportPlot):
             extra_plot_cfg=extra_plot_cfg,
         )
 
+    def save(
+        self, path: tp.Optional[Path] = None, filetype: str = 'svg'
+    ) -> None:
+        """
+        Save the current plot to a file.
+
+        Args:
+            path: The path where the file is stored (excluding the file name).
+            filetype: The file type of the plot.
+        """
+        self.plot(False)
+
+        if path is None:
+            plot_dir = Path(self.plot_kwargs["plot_dir"])
+        else:
+            plot_dir = path
+
+        # TODO (se-passau/VaRA#545): refactor dpi into plot_config. see.
+        plt.savefig(
+            plot_dir / f"{self.name}.{filetype}",
+            dpi=1200,
+            format=filetype,
+            bbox_inches='tight'
+        )
+        plt.close()
+
 
 class BlameVerifierReportOptPlot(BlameVerifierReportPlot):
     """Plotting the successful and failed annotations of reports with


### PR DESCRIPTION
The save function for NoOpt verifier plots was missing and therefore single plot files were created for every project. Multiple project plots now get plotted only once in one file.