### PR TITLE
Handle empty plot data exception in multi plot

### DIFF
--- a/varats/varats/plots/blame_verifier_report_plots.py
+++ b/varats/varats/plots/blame_verifier_report_plots.py
@@ -46,10 +46,11 @@ def _get_named_df_for_case_study(
             return None
 
         # Need more than one data point
-        raise PlotDataEmpty(
+        LOG.warning(
             f"No data found for project {project_name} with optimization level "
             f"{opt_level.value}"
         )
+        raise PlotDataEmpty
 
     named_verifier_df = {
         "project_name": project_name,
@@ -130,7 +131,8 @@ def _verifier_plot(
         )
 
     if not final_plot_data:
-        raise PlotDataEmpty("No plot data was provided")
+        LOG.warning("No plot data was provided")
+        raise PlotDataEmpty
 
     if _is_multi_cs_plot() and len(final_plot_data) > 1:
         _verifier_plot_multiple(plot_cfg, final_plot_data)

--- a/varats/varats/plots/blame_verifier_report_plots.py
+++ b/varats/varats/plots/blame_verifier_report_plots.py
@@ -40,6 +40,11 @@ def _get_named_df_for_case_study(
     if verifier_plot_df.empty or len(
         np.unique(verifier_plot_df['revision'])
     ) == 1:
+        if _is_multi_cs_plot():
+            raise RuntimeWarning(
+                f"Project {project_name} did not provide any plot data"
+            )
+
         # Need more than one data point
         raise PlotDataEmpty
 
@@ -96,7 +101,12 @@ def _load_all_named_dataframes(
                                                         pd.DataFrame]]] = []
 
     for case_study in sorted(all_case_studies, key=lambda cs: cs.project_name):
-        all_named_dataframes.append(_get_named_df_for_case_study(case_study))
+        try:
+            all_named_dataframes.append(
+                _get_named_df_for_case_study(case_study)
+            )
+        except RuntimeWarning:
+            continue
 
     return all_named_dataframes
 
@@ -214,7 +224,7 @@ def _verifier_plot_multiple(
             label=plot_data[0]
         )
     main_axis.title.set_text(
-        str(plot_cfg['fig_title']) + f' - Project(s) {project_names}'
+        str(plot_cfg['fig_title']) + f' - Project(s): \n{project_names}'
     )
 
     plt.setp(

--- a/varats/varats/plots/blame_verifier_report_plots.py
+++ b/varats/varats/plots/blame_verifier_report_plots.py
@@ -248,32 +248,6 @@ class BlameVerifierReportPlot(Plot):
     def calc_missing_revisions(self, boundary_gradient: float) -> tp.Set[str]:
         pass
 
-
-class BlameVerifierReportNoOptPlot(BlameVerifierReportPlot):
-    """Plotting the successful and failed annotations of reports without
-    optimization."""
-    NAME = 'b_verifier_report_no_opt_plot'
-
-    def __init__(self, **kwargs: tp.Any) -> None:
-        super().__init__(self.NAME, **kwargs)
-
-    def plot(self, view_mode: bool) -> None:
-        legend_title: str
-
-        if _is_multi_cs_plot():
-            legend_title = "Success rate of projects:"
-        else:
-            legend_title = "Annotation types:"
-
-        extra_plot_cfg = {
-            'fig_title': 'Annotated project revisions with optimization',
-            'legend_title': legend_title
-        }
-        _verifier_plot(
-            opt_level=OptLevel.NO_OPT,
-            extra_plot_cfg=extra_plot_cfg,
-        )
-
     def save(
         self, path: tp.Optional[Path] = None, filetype: str = 'svg'
     ) -> None:
@@ -299,6 +273,32 @@ class BlameVerifierReportNoOptPlot(BlameVerifierReportPlot):
             bbox_inches='tight'
         )
         plt.close()
+
+
+class BlameVerifierReportNoOptPlot(BlameVerifierReportPlot):
+    """Plotting the successful and failed annotations of reports without
+    optimization."""
+    NAME = 'b_verifier_report_no_opt_plot'
+
+    def __init__(self, **kwargs: tp.Any) -> None:
+        super().__init__(self.NAME, **kwargs)
+
+    def plot(self, view_mode: bool) -> None:
+        legend_title: str
+
+        if _is_multi_cs_plot():
+            legend_title = "Success rate of projects:"
+        else:
+            legend_title = "Annotation types:"
+
+        extra_plot_cfg = {
+            'fig_title': 'Annotated project revisions without optimization',
+            'legend_title': legend_title
+        }
+        _verifier_plot(
+            opt_level=OptLevel.NO_OPT,
+            extra_plot_cfg=extra_plot_cfg,
+        )
 
 
 class BlameVerifierReportOptPlot(BlameVerifierReportPlot):
@@ -325,29 +325,3 @@ class BlameVerifierReportOptPlot(BlameVerifierReportPlot):
             opt_level=OptLevel.OPT,
             extra_plot_cfg=extra_plot_cfg,
         )
-
-    def save(
-        self, path: tp.Optional[Path] = None, filetype: str = 'svg'
-    ) -> None:
-        """
-        Save the current plot to a file.
-
-        Args:
-            path: The path where the file is stored (excluding the file name).
-            filetype: The file type of the plot.
-        """
-        self.plot(False)
-
-        if path is None:
-            plot_dir = Path(self.plot_kwargs["plot_dir"])
-        else:
-            plot_dir = path
-
-        # TODO (se-passau/VaRA#545): refactor dpi into plot_config. see.
-        plt.savefig(
-            plot_dir / f"{self.name}.{filetype}",
-            dpi=1200,
-            format=filetype,
-            bbox_inches='tight'
-        )
-        plt.close()

--- a/varats/varats/plots/blame_verifier_report_plots.py
+++ b/varats/varats/plots/blame_verifier_report_plots.py
@@ -132,7 +132,7 @@ def _verifier_plot(
     if not final_plot_data:
         raise PlotDataEmpty("No plot data was provided")
 
-    if _is_multi_cs_plot():
+    if _is_multi_cs_plot() and len(final_plot_data) > 1:
         _verifier_plot_multiple(plot_cfg, final_plot_data)
     else:
         # Pass the only list item of the plot data

--- a/varats/varats/plots/blame_verifier_report_plots.py
+++ b/varats/varats/plots/blame_verifier_report_plots.py
@@ -199,6 +199,7 @@ def _verifier_plot_multiple(
 ) -> None:
     fig = plt.figure()
     main_axis = fig.subplots()
+    main_axis.set_xlim(0, 1)
     project_names: str = "| "
     main_axis.grid(linestyle='--')
     main_axis.set_xlabel('Revisions normalized')
@@ -208,12 +209,15 @@ def _verifier_plot_multiple(
 
     for plot_data in final_plot_data:
         project_names += plot_data[0] + " | "
-        revisions_as_number = np.array([
+
+        # Save an unique int for each varying revision to prepare the data
+        # for the normalization on the x-axis
+        revisions_as_numbers = np.array([
             x + 1 for x, y in enumerate(plot_data[1]["revisions"])
         ]).reshape(-1, 1)
 
-        normalized_revisions = preprocessing.normalize(
-            revisions_as_number, axis=0
+        normalized_revisions = preprocessing.minmax_scale(
+            revisions_as_numbers, (0, 1), axis=0, copy=False
         )
         main_axis.plot(
             normalized_revisions,

--- a/varats/varats/plots/blame_verifier_report_plots.py
+++ b/varats/varats/plots/blame_verifier_report_plots.py
@@ -131,7 +131,6 @@ def _verifier_plot(
         )
 
     if not final_plot_data:
-        LOG.warning("No plot data was provided")
         raise PlotDataEmpty
 
     if _is_multi_cs_plot() and len(final_plot_data) > 1:

--- a/varats/varats/plots/blame_verifier_report_plots.py
+++ b/varats/varats/plots/blame_verifier_report_plots.py
@@ -274,6 +274,32 @@ class BlameVerifierReportNoOptPlot(BlameVerifierReportPlot):
             extra_plot_cfg=extra_plot_cfg,
         )
 
+    def save(
+        self, path: tp.Optional[Path] = None, filetype: str = 'svg'
+    ) -> None:
+        """
+        Save the current plot to a file.
+
+        Args:
+            path: The path where the file is stored (excluding the file name).
+            filetype: The file type of the plot.
+        """
+        self.plot(False)
+
+        if path is None:
+            plot_dir = Path(self.plot_kwargs["plot_dir"])
+        else:
+            plot_dir = path
+
+        # TODO (se-passau/VaRA#545): refactor dpi into plot_config. see.
+        plt.savefig(
+            plot_dir / f"{self.name}.{filetype}",
+            dpi=1200,
+            format=filetype,
+            bbox_inches='tight'
+        )
+        plt.close()
+
 
 class BlameVerifierReportOptPlot(BlameVerifierReportPlot):
     """Plotting the successful and failed annotations of reports with


### PR DESCRIPTION
When multiple case studies are present and one or more do not provide plotting data, the plot should not fail completely but plot the available project data into one file. This commit handles the described scenario for multiple projects where some projects do not provide data.