### PR TITLE
Do not try to discover projects inside project filter generator

### DIFF
--- a/varats/varats/paper_mgmt/paper_config.py
+++ b/varats/varats/paper_mgmt/paper_config.py
@@ -22,7 +22,6 @@ from varats.paper_mgmt.artefacts import (
     load_artefacts_from_file,
     store_artefacts,
 )
-from varats.projects.discover_projects import initialize_projects
 from varats.utils.exceptions import ConfigurationLookupError
 from varats.utils.settings import vara_cfg
 
@@ -202,7 +201,6 @@ def project_filter_generator(project_name: str) -> tp.Callable[[str], bool]:
             )
         )
 
-    initialize_projects()
     return get_paper_config().get_filter_for_case_study(project_name)
 
 


### PR DESCRIPTION
The filter generator is only called when a project is loaded, i.e., while the projects are already being disccovered. This caused unnecessary and unintended recursion during project discovery.

Resolves se-passau/VaRA#705