### PR TITLE
Add switch to select output format of vara-table

### DIFF
--- a/varats-core/varats/table/tables.py
+++ b/varats-core/varats/table/tables.py
@@ -87,7 +87,7 @@ def build_table(table_to_build: 'table.Table') -> None:
         table: the table to build
     """
     if table_to_build.table_kwargs["view"]:
-        table_to_build.format = table_kwargs["output-format"]
+        table_to_build.format = table_to_build.table_kwargs["output-format"]
         print(table_to_build.tabulate())
     else:
         table_to_build.save(

--- a/varats-core/varats/table/tables.py
+++ b/varats-core/varats/table/tables.py
@@ -88,7 +88,7 @@ def build_table(table_to_build: 'table.Table') -> None:
     """
     if table_to_build.table_kwargs["view"]:
         from varats.table.table import TableFormat  # pylint: disable=C0415
-        table_to_build.format = TableFormat.fancy_grid
+        table_to_build.format = table_kwargs["output-format"]
         print(table_to_build.tabulate())
     else:
         table_to_build.save(

--- a/varats-core/varats/table/tables.py
+++ b/varats-core/varats/table/tables.py
@@ -86,8 +86,8 @@ def build_table(table_to_build: 'table.Table') -> None:
     Args:
         table: the table to build
     """
+    table_to_build.format = table_to_build.table_kwargs["output-format"]
     if table_to_build.table_kwargs["view"]:
-        table_to_build.format = table_to_build.table_kwargs["output-format"]
         print(table_to_build.tabulate())
     else:
         table_to_build.save(
@@ -140,6 +140,12 @@ def prepare_tables(**args: tp.Any) -> tp.Iterable['table.Table']:
 
     if 'view' not in args:
         args['view'] = False
+    if 'output-format' not in args:
+        from varats.table.table import TableFormat  # pylint: disable=C0415
+        if args['view']:
+            args['output-format'] = TableFormat.fancy_grid
+        else:
+            args['output-format'] = TableFormat.latex_booktabs
     if 'paper_config' not in args:
         args['paper_config'] = False
 

--- a/varats-core/varats/table/tables.py
+++ b/varats-core/varats/table/tables.py
@@ -87,7 +87,6 @@ def build_table(table_to_build: 'table.Table') -> None:
         table: the table to build
     """
     if table_to_build.table_kwargs["view"]:
-        from varats.table.table import TableFormat  # pylint: disable=C0415
         table_to_build.format = table_kwargs["output-format"]
         print(table_to_build.tabulate())
     else:

--- a/varats/varats/tools/driver_table.py
+++ b/varats/varats/tools/driver_table.py
@@ -4,8 +4,11 @@ import argparse
 import logging
 import typing as tp
 
+from argparse_utils import enum_action
+
 from varats.data.discover_reports import initialize_reports
 from varats.projects.discover_projects import initialize_projects
+from varats.table.table import TableFormat
 from varats.table.tables import TableRegistry, build_tables
 from varats.tables.discover_tables import initialize_tables
 from varats.utils.cli_util import initialize_cli_tool
@@ -57,6 +60,12 @@ def main() -> None:
         help="The report type to generate the table for."
         "Tables may ignore this option.",
         default="EmptyReport"
+    )
+    parser.add_argument(
+        "--output-format",
+        help="The format the table should have",
+        action=enum_action(TableFormat),
+        default=TableFormat.fancy_grid
     )
     parser.add_argument(
         "extra_args",

--- a/varats/varats/tools/driver_table.py
+++ b/varats/varats/tools/driver_table.py
@@ -64,8 +64,7 @@ def main() -> None:
     parser.add_argument(
         "--output-format",
         help="The format the table should have",
-        action=enum_action(TableFormat),
-        default=TableFormat.fancy_grid
+        action=enum_action(TableFormat)
     )
     parser.add_argument(
         "extra_args",


### PR DESCRIPTION
Add an argument "output-format" to the vara-table tool to specify the format of the table. Closes se-passau/VaRA#699