### PR TITLE
Fix remote to point to github

### DIFF
--- a/varats/varats/projects/c_projects/grep.py
+++ b/varats/varats/projects/c_projects/grep.py
@@ -26,7 +26,7 @@ class Grep(bb.Project, CVEProviderHook):  # type: ignore
 
     SOURCE = [
         bb.source.Git(
-            remote="https://github.com/Distrotech/grep.git",
+            remote="https://github.com/vulder/grep.git",
             local="grep",
             refspec="HEAD",
             limit=None,

--- a/varats/varats/projects/c_projects/grep.py
+++ b/varats/varats/projects/c_projects/grep.py
@@ -26,7 +26,7 @@ class Grep(bb.Project, CVEProviderHook):  # type: ignore
 
     SOURCE = [
         bb.source.Git(
-            remote="https://git.savannah.gnu.org/git/grep.git",
+            remote="https://github.com/Distrotech/grep.git",
             local="grep",
             refspec="HEAD",
             limit=None,
@@ -34,7 +34,7 @@ class Grep(bb.Project, CVEProviderHook):  # type: ignore
             version_filter=project_filter_generator("grep")
         ),
         bb.source.GitSubmodule(
-            remote="https://git.savannah.gnu.org/git/gnulib.git",
+            remote="https://github.com/coreutils/gnulib.git",
             local="grep/gnulib",
             refspec="HEAD",
             limit=None,

--- a/varats/varats/projects/c_projects/gzip.py
+++ b/varats/varats/projects/c_projects/gzip.py
@@ -41,7 +41,7 @@ class Gzip(bb.Project, ReleaseProviderHook, CVEProviderHook):  # type: ignore
             )
         ])(
             bb.source.Git(
-                remote="https://git.savannah.gnu.org/git/gzip.git",
+                remote="https://github.com/Distrotech/gzip.git",
                 local="gzip",
                 refspec="HEAD",
                 limit=None,
@@ -50,7 +50,7 @@ class Gzip(bb.Project, ReleaseProviderHook, CVEProviderHook):  # type: ignore
             )
         ),
         bb.source.GitSubmodule(
-            remote="https://git.savannah.gnu.org/git/gnulib.git",
+            remote="https://github.com/coreutils/gnulib.git",
             local="gzip/gnulib",
             refspec="HEAD",
             limit=None,

--- a/varats/varats/projects/c_projects/gzip.py
+++ b/varats/varats/projects/c_projects/gzip.py
@@ -41,7 +41,7 @@ class Gzip(bb.Project, ReleaseProviderHook, CVEProviderHook):  # type: ignore
             )
         ])(
             bb.source.Git(
-                remote="https://github.com/Distrotech/gzip.git",
+                remote="https://github.com/vulder/gzip.git",
                 local="gzip",
                 refspec="HEAD",
                 limit=None,


### PR DESCRIPTION
savannah.gnu.org is a very restricted and unsable remote, hence we use
github (own) mirrors to prevent clone/fetch failures.