### PR TITLE
Adds test to check if project names are well formed

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -65,7 +65,7 @@ class _ReplaceConfig():
         self.replace_bb_config = replace_bb_config
         if self.replace_bb_config:
             # pylint: disable=protected-access
-            self.old_bb_config = settings._BB_CFG
+            self.old_bb_config = settings.bb_cfg()
             if bb_config:
                 self.new_bb_config = bb_config
             else:
@@ -78,7 +78,7 @@ class _ReplaceConfig():
             tmp_path = Path(self.tmp_path.name)
 
         # pylint: disable=protected-access
-        self.old_config = settings._CFG
+        self.old_config = settings.vara_cfg()
         if vara_config:
             self.new_config = vara_config
         else:

--- a/tests/utils/test_project_util.py
+++ b/tests/utils/test_project_util.py
@@ -230,8 +230,9 @@ class TestVaraTestRepoSource(unittest.TestCase):
             tmp_file = tempfile.NamedTemporaryFile()
             generate_benchbuild_config(vara_cfg, tmp_file.name)
             bb_cfg.load(tmp_file.name)
+            loaded_project_paths: tp.List[str] = bb_cfg["plugins"]["projects"
+                                                                  ].value
 
-        loaded_project_paths: tp.List[str] = bb_cfg["plugins"]["projects"].value
         loaded_project_names = [
             project_path.rsplit(sep='.', maxsplit=1)[1]
             for project_path in loaded_project_paths

--- a/varats-core/varats/utils/settings.py
+++ b/varats-core/varats/utils/settings.py
@@ -177,7 +177,7 @@ _BB_CFG: tp.Optional[s.Configuration] = None
 
 
 def bb_cfg() -> s.Configuration:
-    """Get the current behcnbuild config."""
+    """Get the current benchbuild config."""
     global _BB_CFG  # pylint: disable=global-statement
     if not _BB_CFG:
         from benchbuild.settings import CFG as BB_CFG  # pylint: disable=C0415


### PR DESCRIPTION
Adds a test to check if the project names are well formed, e.g., they must not contain a dash character.

closes https://github.com/se-sic/VaRA/issues/721