### PR TITLE
Fix Repo Path Dependecy In Bug Provider Test Module

### DIFF
--- a/tests/provider/test_bug_provider.py
+++ b/tests/provider/test_bug_provider.py
@@ -90,7 +90,9 @@ class DummyPydrillerRepo(pydrepo.Git):
     }
 
     def __init__(self, _path):
-        super().__init__("")
+        """Overrides superclass constructor in order to gain Independence of a
+        valid Git Repo path."""
+        pass
 
     @staticmethod
     def fix_firstbug() -> MagicMock:


### PR DESCRIPTION
Removes the superclass call inside the DummyPydrillerRepo class in the BugProvider test module in order to gain independence of the local folder in which to run the tests, since any folder besides the root folder of the repository would cause an InvalidGitRepositoryError.