### PR TITLE
Add PhASAR experiment

### DIFF
--- a/varats/varats/data/reports/points_to_analysis_perf_report.py
+++ b/varats/varats/data/reports/points_to_analysis_perf_report.py
@@ -1,0 +1,58 @@
+from varats.report.report import BaseReport, FileStatusExtension, MetaReport
+
+class PointsToAnalysisPerfReport(BaseReport):
+    SHORTHAND = "PTAPR"
+    FILE_TYPE = "json"
+
+    @staticmethod
+    def get_file_name(
+        project_name: str,
+        binary_name: str,
+        project_version: str,
+        project_uuid: str,
+        extension_type: FileStatusExtension,
+        file_ext: str = ".txt"
+    ) -> str:
+        """
+        Generates a filename for a commit report with 'yaml' as file extension.
+
+        Args:
+            project_name: name of the project for which the report was generated
+            binary_name: name of the binary for which the report was generated
+            project_version: version of the analyzed project, i.e., commit hash
+            project_uuid: benchbuild uuid for the experiment run
+            extension_type: to specify the status of the generated report
+            file_ext: file extension of the report file
+
+        Returns:
+            name for the report file that can later be uniquly identified
+        """
+        return MetaReport.get_file_name(
+            PointsToAnalysisPerfReport.SHORTHAND, project_name, binary_name, project_version,
+            project_uuid, extension_type, file_ext
+        )
+
+    @staticmethod
+    def get_supplementary_file_name(
+        project_name: str, binary_name: str, project_version: str,
+        project_uuid: str, info_type: str, file_ext: str
+    ) -> str:
+        """
+        Generates a filename for a commit report supplementary file.
+
+        Args:
+            project_name: name of the project for which the report was generated
+            binary_name: name of the binary for which the report was generated
+            project_version: version of the analyzed project, i.e., commit hash
+            project_uuid: benchbuild uuid for the experiment run
+            info_type: specifies the kind of supplementary file
+            file_ext: file extension of the report file
+
+        Returns:
+            name for the supplementary report file that can later be uniquly
+            identified
+        """
+        return BaseReport.get_supplementary_file_name(
+            PointsToAnalysisPerfReport.SHORTHAND, project_name, binary_name, project_version,
+            project_uuid, info_type, file_ext
+        )

--- a/varats/varats/data/reports/points_to_analysis_perf_report.py
+++ b/varats/varats/data/reports/points_to_analysis_perf_report.py
@@ -11,7 +11,7 @@ class PointsToAnalysisPerfReport(BaseReport):
         project_version: str,
         project_uuid: str,
         extension_type: FileStatusExtension,
-        file_ext: str = ".txt"
+        file_ext: str = PointsToAnalysisPerfReport.FILE_TYPE
     ) -> str:
         """
         Generates a filename for a commit report with 'yaml' as file extension.

--- a/varats/varats/experiments/phasar/points_to_analysis_experiment.py
+++ b/varats/varats/experiments/phasar/points_to_analysis_experiment.py
@@ -1,0 +1,161 @@
+"""Module for phasar points to analyses."""
+import typing as tp
+from os import path
+
+import benchbuild.utils.actions as actions
+from benchbuild import Project  # type: ignore
+from benchbuild.extensions import compiler, run, time
+from benchbuild.utils.cmd import mkdir
+from plumbum import local
+
+from varats.report.report import FileStatusExtension as FSE
+# from varats.data.reports.empty_report import EmptyReport
+from varats.data.reports.points_to_analysis_perf_report import PointsToAnalysisPerfReport
+from varats.experiment.wllvm import (
+    RunWLLVM,
+    get_cached_bc_file_path,
+    get_bc_cache_actions,
+)
+from varats.experiment.experiment_util import (
+    PEErrorHandler,
+    VersionExperiment,
+    wrap_unlimit_stack_size,
+    get_default_compile_error_wrapped,
+    exec_func_with_pe_error_handler,
+)
+from varats.utils.settings import bb_cfg
+
+
+class PointsToAnalysis(actions.Step):  # type: ignore
+    """Analysis step to run a points to analysis on a project."""
+
+    NAME = "PointsToAnalysis"
+    DESCRIPTION = (
+        "TODO: Add description"
+    )
+    RESULT_FOLDER_TEMPLATE = "{result_dir}/{project_dir}"
+
+    def __init__(
+        self,
+        project: Project,
+        tool
+    ):
+        super().__init__(obj=project, action_fn=self.analyze)
+        self.tool = tool
+
+    def analyze(self) -> actions.StepResult:
+        """Run a phasar tool"""
+        if not self.obj:
+            return
+        project = self.obj
+
+        # Add to the user-defined path for saving the results of the
+        # analysis also the name and the unique id of the project of every
+        # run.
+        varats_result_folder = self.RESULT_FOLDER_TEMPLATE.format(
+            result_dir=str(bb_cfg()["varats"]["outfile"]),
+            project_dir=str(project.name)
+        )
+
+        mkdir("-p", varats_result_folder)
+
+        phasar_tool = local[self.tool]
+        for binary in project.binaries:
+            bc_file = get_cached_bc_file_path(project, binary)
+
+            # Text report of analysis
+            result_file = PointsToAnalysisPerfReport.get_file_name(
+                project_name=str(project.name),
+                binary_name=f'{self.tool}_{binary.name}',
+                project_version=project.version_of_primary,
+                project_uuid=str(project.run_uuid),
+                extension_type=FSE.Success
+            )
+
+            # PAMM result file
+            pamm_file = PointsToAnalysisPerfReport.get_supplementary_file_name(
+                project_name=str(project.name),
+                binary_name=f'{self.tool}_{binary.name}',
+                project_version=project.version_of_primary,
+                project_uuid=str(project.run_uuid),
+                info_type="PAMM",
+                file_ext=".json"
+            )
+
+            parameters = [bc_file, f'{varats_result_folder}/{pamm_file}']
+            run_cmd = wrap_unlimit_stack_size(phasar_tool[parameters])
+            run_cmd = (run_cmd > f'{varats_result_folder}/{result_file}')
+
+            exec_func_with_pe_error_handler(
+                run_cmd,
+                PEErrorHandler(
+                    varats_result_folder,
+                    PointsToAnalysisPerfReport.get_file_name(
+                        project_name=str(project.name),
+                        binary_name=binary.name,
+                        project_version=project.version_of_primary,
+                        project_uuid=str(project.run_uuid),
+                        extension_type=FSE.Failed,
+                        file_ext=".txt"
+                    )
+                )
+            )
+
+
+class PointsToAnalysisExperiment(VersionExperiment):
+    """Experiment class to build and analyse a project with a custom PhASAR tool."""
+
+    NAME = "PhasarPointsToAnalysis"
+
+    REPORT_TYPE = PointsToAnalysisPerfReport
+
+    def actions_for_project(self, project: Project) -> tp.List[actions.Step]:
+        """
+        Returns the specified steps to run the project(s) specified in the call
+        in a fixed order.
+
+        Args:
+            project: to analyze
+        """
+
+        # Add the required runtime extensions to the project(s).
+        project.runtime_extension = run.RuntimeExtension(project, self) \
+            << time.RunWithTime()
+
+        # Add the required compiler extensions to the project(s).
+        project.compiler_extension = compiler.RunCompiler(project, self) \
+            << RunWLLVM() \
+            << run.WithTimeout()
+
+        # Add own error handler to compile step.
+        project.compile = get_default_compile_error_wrapped(
+            project, PointsToAnalysisPerfReport,
+            PointsToAnalysis.RESULT_FOLDER_TEMPLATE
+        )
+
+        varats_result_folder = \
+            f"{bb_cfg()['varats']['outfile']}/{project.name}"
+
+        error_handler = PEErrorHandler(
+            varats_result_folder,
+            PointsToAnalysisPerfReport.get_file_name(
+                project_name=str(project.name),
+                binary_name="all",
+                project_version=project.version_of_primary,
+                project_uuid=str(project.run_uuid),
+                extension_type=FSE.CompileError,
+                file_ext=".txt"
+            )
+        )
+
+        analysis_actions = []
+
+        analysis_actions += get_bc_cache_actions(
+            project, extraction_error_handler=error_handler
+        )
+
+        analysis_actions.append(PointsToAnalysis(project, "myphasar_tool"))
+
+        analysis_actions.append(actions.Clean(project))
+
+        return analysis_actions

--- a/varats/varats/experiments/phasar/points_to_analysis_experiment.py
+++ b/varats/varats/experiments/phasar/points_to_analysis_experiment.py
@@ -8,21 +8,23 @@ from benchbuild.extensions import compiler, run, time
 from benchbuild.utils.cmd import mkdir
 from plumbum import local
 
-from varats.report.report import FileStatusExtension as FSE
 # from varats.data.reports.empty_report import EmptyReport
-from varats.data.reports.points_to_analysis_perf_report import PointsToAnalysisPerfReport
-from varats.experiment.wllvm import (
-    RunWLLVM,
-    get_cached_bc_file_path,
-    get_bc_cache_actions,
+from varats.data.reports.points_to_analysis_perf_report import (
+    PointsToAnalysisPerfReport,
 )
 from varats.experiment.experiment_util import (
     PEErrorHandler,
     VersionExperiment,
-    wrap_unlimit_stack_size,
-    get_default_compile_error_wrapped,
     exec_func_with_pe_error_handler,
+    get_default_compile_error_wrapped,
+    wrap_unlimit_stack_size,
 )
+from varats.experiment.wllvm import (
+    RunWLLVM,
+    get_bc_cache_actions,
+    get_cached_bc_file_path,
+)
+from varats.report.report import FileStatusExtension as FSE
 from varats.utils.settings import bb_cfg
 
 
@@ -30,16 +32,10 @@ class PointsToAnalysis(actions.Step):  # type: ignore
     """Analysis step to run a points to analysis on a project."""
 
     NAME = "PointsToAnalysis"
-    DESCRIPTION = (
-        "TODO: Add description"
-    )
+    DESCRIPTION = "TODO: Add description"
     RESULT_FOLDER_TEMPLATE = "{result_dir}/{project_dir}"
 
-    def __init__(
-        self,
-        project: Project,
-        tool
-    ) -> None:
+    def __init__(self, project: Project, tool: str) -> None:
         super().__init__(obj=project, action_fn=self.analyze)
         self.tool = tool
 
@@ -53,8 +49,7 @@ class PointsToAnalysis(actions.Step):  # type: ignore
         # analysis also the name and the unique id of the project of every
         # run.
         varats_result_folder = self.RESULT_FOLDER_TEMPLATE.format(
-            result_dir=str(bb_cfg()["varats"]["outfile"]),
-            project_dir=str(project.name)
+            result_dir=str(bb_cfg()["varats"]["outfile"]), project_dir=str(project.name)
         )
 
         mkdir("-p", varats_result_folder)
@@ -66,25 +61,25 @@ class PointsToAnalysis(actions.Step):  # type: ignore
             # Text report of analysis
             result_file = PointsToAnalysisPerfReport.get_file_name(
                 project_name=str(project.name),
-                binary_name=f'{self.tool}_{binary.name}',
+                binary_name=f"{self.tool}_{binary.name}",
                 project_version=project.version_of_primary,
                 project_uuid=str(project.run_uuid),
-                extension_type=FSE.Success
+                extension_type=FSE.Success,
             )
 
             # PAMM result file
             pamm_file = PointsToAnalysisPerfReport.get_supplementary_file_name(
                 project_name=str(project.name),
-                binary_name=f'{self.tool}_{binary.name}',
+                binary_name=f"{self.tool}_{binary.name}",
                 project_version=project.version_of_primary,
                 project_uuid=str(project.run_uuid),
                 info_type="PAMM",
-                file_ext=".json"
+                file_ext=".json",
             )
 
-            parameters = [bc_file, f'{varats_result_folder}/{pamm_file}']
+            parameters = [bc_file, f"{varats_result_folder}/{pamm_file}"]
             run_cmd = wrap_unlimit_stack_size(phasar_tool[parameters])
-            run_cmd = (run_cmd > f'{varats_result_folder}/{result_file}')
+            run_cmd = run_cmd > f"{varats_result_folder}/{result_file}"
 
             exec_func_with_pe_error_handler(
                 run_cmd,
@@ -96,9 +91,9 @@ class PointsToAnalysis(actions.Step):  # type: ignore
                         project_version=project.version_of_primary,
                         project_uuid=str(project.run_uuid),
                         extension_type=FSE.Failed,
-                        file_ext=".txt"
-                    )
-                )
+                        file_ext=".txt",
+                    ),
+                ),
             )
 
 
@@ -119,22 +114,19 @@ class PointsToAnalysisExperiment(VersionExperiment):
         """
 
         # Add the required runtime extensions to the project(s).
-        project.runtime_extension = run.RuntimeExtension(project, self) \
-            << time.RunWithTime()
+        project.runtime_extension = run.RuntimeExtension(project, self) << time.RunWithTime()
 
         # Add the required compiler extensions to the project(s).
-        project.compiler_extension = compiler.RunCompiler(project, self) \
-            << RunWLLVM() \
-            << run.WithTimeout()
+        project.compiler_extension = (
+            compiler.RunCompiler(project, self) << RunWLLVM() << run.WithTimeout()
+        )
 
         # Add own error handler to compile step.
         project.compile = get_default_compile_error_wrapped(
-            project, PointsToAnalysisPerfReport,
-            PointsToAnalysis.RESULT_FOLDER_TEMPLATE
+            project, PointsToAnalysisPerfReport, PointsToAnalysis.RESULT_FOLDER_TEMPLATE
         )
 
-        varats_result_folder = \
-            f"{bb_cfg()['varats']['outfile']}/{project.name}"
+        varats_result_folder = f"{bb_cfg()['varats']['outfile']}/{project.name}"
 
         error_handler = PEErrorHandler(
             varats_result_folder,
@@ -144,15 +136,13 @@ class PointsToAnalysisExperiment(VersionExperiment):
                 project_version=project.version_of_primary,
                 project_uuid=str(project.run_uuid),
                 extension_type=FSE.CompileError,
-                file_ext=".txt"
-            )
+                file_ext=".txt",
+            ),
         )
 
         analysis_actions = []
 
-        analysis_actions += get_bc_cache_actions(
-            project, extraction_error_handler=error_handler
-        )
+        analysis_actions += get_bc_cache_actions(project, extraction_error_handler=error_handler)
 
         analysis_actions.append(PointsToAnalysis(project, "myphasar_tool"))
 

--- a/varats/varats/experiments/phasar/points_to_analysis_experiment.py
+++ b/varats/varats/experiments/phasar/points_to_analysis_experiment.py
@@ -39,7 +39,7 @@ class PointsToAnalysis(actions.Step):  # type: ignore
         self,
         project: Project,
         tool
-    ):
+    ) -> None:
         super().__init__(obj=project, action_fn=self.analyze)
         self.tool = tool
 

--- a/varats/varats/tools/bb_config.py
+++ b/varats/varats/tools/bb_config.py
@@ -82,6 +82,7 @@ def generate_benchbuild_config(
         'varats.experiments.vara.vara_full_mtfa',
         'varats.experiments.vara.blame_verifier_experiment',
         'varats.experiments.phasar.ide_linear_constant_experiment',
+        'varats.experiments.phasar.points_to_analysis_experiment',
         'varats.experiments.szz.szz_unleashed_experiment',
     ]
 


### PR DESCRIPTION
### Description

This PR adds an experiment for an analysis that creates an resultPAMM.json file and some textoutput.

The following example tool takes a `.bc` or `.ll` file and creates a `PAMM.json` file and some text output.
```
#include <filesystem>
#include <iostream>

#include "phasar/DB/ProjectIRDB.h"
#include "phasar/PhasarLLVM/ControlFlow/LLVMBasedICFG.h"
#include "phasar/PhasarLLVM/Pointer/LLVMPointsToSet.h"
#include "phasar/PhasarLLVM/TypeHierarchy/LLVMTypeHierarchy.h"
#include "phasar/Utils/Logger.h"
#include "phasar/Utils/PAMM.h"

using namespace psr;

int main(int Argc, const char **Argv) {
  initializeLogger(false);

  // Check arguments
  if (Argc != 3 || !std::filesystem::exists(Argv[1])) {
    std::cerr << "pammtool\n"
                 "Usage: pammtool <LLVM IR file> <PAMM output file>\n";
    return 1;
  }

  PAMM &Pamm = PAMM::getInstance();
  Pamm.startTimer("timer1");
  Pamm.regHistogram("Test-Set");
  Pamm.addToHistogram("Test-Set", "1");
  Pamm.addToHistogram("Test-Set", "2");
  Pamm.addToHistogram("Test-Set", "3");
  Pamm.stopTimer("timer1");
  // Export PAMM file
  Pamm.exportMeasuredData(Argv[2]);

  // Check for a main function
  ProjectIRDB DB({Argv[1]});
  if (const auto *F = DB.getFunctionDefinition("main")) {
    std::cout << "The file contains a 'main' function!\n";
  } else {
    std::cerr << "ERROR: file does not contain a 'main' function!\n";
  }

  return 0;
}
```

Currently the binary of the dummytool/analysistool has to be copied manually to `vara-root/tools/phasar/bin/pammtool`
