### PR TITLE
Replace revision strings with CommitHash types

### DIFF
--- a/tests/data/test_diff_correlation_overview_table.py
+++ b/tests/data/test_diff_correlation_overview_table.py
@@ -5,6 +5,7 @@ import pytest
 
 from tests.test_utils import run_in_test_environment, UnitTestInputs
 from varats.paper_mgmt.paper_config import load_paper_config
+from varats.projects.discover_projects import initialize_projects
 from varats.tables import diff_correlation_overview_table
 from varats.utils.settings import vara_cfg
 
@@ -21,6 +22,7 @@ class TestDiffCorrelationOverviewTable(unittest.TestCase):
         """Check whether the table produces the correct tex output."""
         vara_cfg()["paper_config"]["current_config"
                                   ] = "test_diff_correlation_overview_table"
+        initialize_projects()
         load_paper_config()
         table = diff_correlation_overview_table.DiffCorrelationOverviewTable(
         ).tabulate()

--- a/varats-core/varats/mapping/commit_map.py
+++ b/varats-core/varats/mapping/commit_map.py
@@ -48,7 +48,7 @@ class CommitMap():
             a full-length commit hash that starts with the short-form hash
         """
         full_commits = self.complete_c_hash(short_commit)
-        if len(full_commits):
+        if len(full_commits) > 1:
             LOG.warning(f"Short commit hash is ambiguous: {short_commit.hash}.")
         return next(iter(full_commits))
 

--- a/varats-core/varats/utils/git_util.py
+++ b/varats-core/varats/utils/git_util.py
@@ -43,9 +43,6 @@ class CommitHash(abc.ABC):
     def from_pygit_commit(commit: pygit2.Commit) -> 'FullCommitHash':
         return FullCommitHash(str(commit.id))
 
-    def __len__(self) -> int:
-        return self.hash_length()
-
     def __str__(self) -> str:
         return self.hash
 
@@ -333,7 +330,7 @@ def create_commit_lookup_helper(project_name: str) -> CommitLookupTy:
             commit = primary_project_repo.get(c_hash.hash)
             if commit is None:
                 raise LookupError(
-                    f"Could not find commit {c_hash.hash} in {project_name}"
+                    f"Could not find commit {c_hash} in {project_name}"
                 )
             cache_dict[primary_source_name][c_hash] = commit
             return commit

--- a/varats-core/varats/utils/git_util.py
+++ b/varats-core/varats/utils/git_util.py
@@ -43,6 +43,9 @@ class CommitHash(abc.ABC):
     def from_pygit_commit(commit: pygit2.Commit) -> 'FullCommitHash':
         return FullCommitHash(str(commit.id))
 
+    def __len__(self) -> int:
+        return self.hash_length()
+
     def __str__(self) -> str:
         return self.hash
 
@@ -330,7 +333,7 @@ def create_commit_lookup_helper(project_name: str) -> CommitLookupTy:
             commit = primary_project_repo.get(c_hash.hash)
             if commit is None:
                 raise LookupError(
-                    f"Could not find commit {c_hash} in {project_name}"
+                    f"Could not find commit {c_hash.hash} in {project_name}"
                 )
             cache_dict[primary_source_name][c_hash] = commit
             return commit
@@ -343,7 +346,7 @@ def create_commit_lookup_helper(project_name: str) -> CommitLookupTy:
         if c_hash in cache_dict[git_name]:
             return cache_dict[git_name][c_hash]
 
-        commit = repos[git_name].get(c_hash)
+        commit = repos[git_name].get(c_hash.hash)
         if commit is None:
             raise LookupError(
                 f"Could not find commit {c_hash} in "

--- a/varats/varats/data/databases/blame_diff_library_interaction_database.py
+++ b/varats/varats/data/databases/blame_diff_library_interaction_database.py
@@ -66,7 +66,7 @@ class BlameDiffLibraryInteractionDatabase(
 
                 data_dict: tp.Dict[str, tp.Any] = {
                     'revision':
-                        head_report.head_commit,
+                        head_report.head_commit.hash,
                     'time_id':
                         commit_map.short_time_id(head_report.head_commit),
                     'base_hash':

--- a/varats/varats/data/databases/blame_diff_metrics_database.py
+++ b/varats/varats/data/databases/blame_diff_metrics_database.py
@@ -321,7 +321,7 @@ class BlameDiffMetricsDatabase(
             return (
                 pd.DataFrame({
                     'revision':
-                        head_report.head_commit,
+                        head_report.head_commit.hash,
                     'time_id':
                         commit_map.short_time_id(head_report.head_commit),
                     'churn':

--- a/varats/varats/data/databases/blame_interaction_database.py
+++ b/varats/varats/data/databases/blame_interaction_database.py
@@ -56,7 +56,7 @@ class BlameInteractionDatabase(
 
             return pd.DataFrame({
                 'revision':
-                    report.head_commit,
+                    report.head_commit.hash,
                 'time_id':
                     commit_map.short_time_id(report.head_commit),
                 'IN_HEAD_Interactions':

--- a/varats/varats/data/databases/blame_interaction_degree_database.py
+++ b/varats/varats/data/databases/blame_interaction_degree_database.py
@@ -146,7 +146,7 @@ class BlameInteractionDegreeDatabase(
             ) -> tp.Dict[str, tp.Any]:
 
                 data_dict: tp.Dict[str, tp.Any] = {
-                    'revision': report.head_commit,
+                    'revision': report.head_commit.hash,
                     'time_id': commit_map.short_time_id(report.head_commit),
                     'degree_type': degree_type.value,
                     'base_lib': base_library,

--- a/varats/varats/data/databases/blame_library_interactions_database.py
+++ b/varats/varats/data/databases/blame_library_interactions_database.py
@@ -58,7 +58,7 @@ class BlameLibraryInteractionsDatabase(
             ) -> tp.Dict[str, tp.Any]:
 
                 data_dict: tp.Dict[str, tp.Any] = {
-                    'revision': report.head_commit,
+                    'revision': report.head_commit.hash,
                     'time_id': commit_map.short_time_id(report.head_commit),
                     'base_hash': base_hash.hash,
                     'base_lib': base_library,

--- a/varats/varats/data/databases/blame_verifier_report_database.py
+++ b/varats/varats/data/databases/blame_verifier_report_database.py
@@ -106,7 +106,7 @@ class BlameVerifierReportDatabase(
 
             return pd.DataFrame(
                 {
-                    'revision': report.head_commit,
+                    'revision': report.head_commit.hash,
                     'time_id': commit_map.short_time_id(report.head_commit),
                     'opt_level': opt_level,
                     'total': number_of_total_annotations,

--- a/varats/varats/data/databases/commit_interaction_database.py
+++ b/varats/varats/data/databases/commit_interaction_database.py
@@ -53,7 +53,7 @@ class CommitInteractionDatabase(
 
             return pd.DataFrame({
                 'revision':
-                    report.head_commit,
+                    report.head_commit.hash,
                 'time_id':
                     commit_map.short_time_id(report.head_commit),
                 'CFInteractions':

--- a/varats/varats/data/databases/evaluationdatabase.py
+++ b/varats/varats/data/databases/evaluationdatabase.py
@@ -94,7 +94,7 @@ class EvaluationDatabase(abc.ABC):
             return data_frame[data_frame["revision"].
                               apply(lambda x: revisions.has_node(x.hash) != 0)]
 
-        # Cast all revisions to ShortCommitHash(es)
+        # Convert all revisions to ShortCommitHash(es)
         data['revision'] = data['revision'].apply(ShortCommitHash)
         data = cs_filter(data)
         return data[columns]

--- a/varats/varats/data/databases/evaluationdatabase.py
+++ b/varats/varats/data/databases/evaluationdatabase.py
@@ -91,10 +91,11 @@ class EvaluationDatabase(abc.ABC):
             revisions = CharTrie()
             for revision in case_study.revisions:
                 revisions[revision.hash] = True
-            return data_frame[data_frame["revision"].apply(
-                lambda x: revisions.has_node(ShortCommitHash(str(x)).hash) != 0
-            )]
+            return data_frame[data_frame["revision"].
+                              apply(lambda x: revisions.has_node(x.hash) != 0)]
 
+        # Cast all revisions to ShortCommitHash(es)
+        data['revision'] = data['revision'].apply(ShortCommitHash)
         data = cs_filter(data)
         return data[columns]
 

--- a/varats/varats/plots/blame_interaction_degree.py
+++ b/varats/varats/plots/blame_interaction_degree.py
@@ -94,8 +94,12 @@ LibraryColormapMapping = tp.Dict[str, tp.Any]
 LibraryToIndexShadesMapping = tp.Dict[str, IndexShadesMapping]
 
 
-def _get_unique_revisions(dataframe: pd.DataFrame) -> tp.List[FullCommitHash]:
-    return [FullCommitHash(rev) for rev in dataframe.revision.unique()]
+def _get_unique_revisions(dataframe: pd.DataFrame,
+                          c_map: CommitMap) -> tp.List[FullCommitHash]:
+    return [
+        c_map.convert_to_full_or_warn(rev)
+        for rev in dataframe.revision.unique()
+    ]
 
 
 def _filter_data_frame(
@@ -137,7 +141,8 @@ def _filter_data_frame(
         interaction_plot_df.loc[interaction_plot_df.degree == x].fraction
         for x in degree_levels
     ]
-    unique_revisions = _get_unique_revisions(interaction_plot_df)
+
+    unique_revisions = _get_unique_revisions(interaction_plot_df, commit_map)
 
     return unique_revisions, sub_df_list
 
@@ -170,8 +175,9 @@ def _generate_stackplot(
     fig.subplots_adjust(top=0.95, hspace=0.05, right=0.95, left=0.07)
     fig.suptitle(plot_cfg["fig_suptitle"], fontsize=8)
 
+    unique_rev_strings: tp.List[str] = [rev.hash for rev in unique_revisions]
     main_axis.stackplot(
-        unique_revisions,
+        unique_rev_strings,
         sub_df_list,
         edgecolor=plot_cfg['edgecolor'],
         colors=reversed(
@@ -862,7 +868,7 @@ class BlameLibraryInteraction(Plot):
         df.sort_values(by=['time_id'], inplace=True)
         commit_map: CommitMap = self.plot_kwargs['get_cmap']()
         df.reset_index(inplace=True)
-        unique_revisions = _get_unique_revisions(df)
+        unique_revisions = _get_unique_revisions(df, commit_map)
 
         for rev in unique_revisions:
             if view_mode and 'revision' in self.plot_kwargs:
@@ -913,7 +919,7 @@ class BlameDegree(Plot):
                     "inter_lib", "degree", "amount", "fraction"
                 ], commit_map, case_study)
 
-        length = len(np.unique(interaction_plot_df['revision']))
+        length = len(_get_unique_revisions(interaction_plot_df, commit_map))
         is_empty = interaction_plot_df.empty
 
         if is_empty or length == 1:
@@ -1058,7 +1064,8 @@ class BlameDegree(Plot):
         all_base_lib_names = _get_distinct_base_lib_names(df)
         all_inter_lib_names = _get_distinct_inter_lib_names(df)
         revision_df = pd.DataFrame(df["revision"])
-        unique_revisions = _get_unique_revisions(revision_df)
+        commit_map: CommitMap = self.plot_kwargs['get_cmap']()
+        unique_revisions = _get_unique_revisions(revision_df, commit_map)
         grouped_df: pd.DataFrame = df.groupby(['revision'])
         revision_to_dataframes_mapping: tp.Dict[FullCommitHash,
                                                 pd.DataFrame] = {}
@@ -1133,9 +1140,10 @@ class BlameDegree(Plot):
             interaction_plot_df.degree_type == degree_type.value]
         interaction_plot_df.sort_values(by=['time_id'], inplace=True)
         interaction_plot_df.reset_index(inplace=True)
-        unique_revisions = _get_unique_revisions(interaction_plot_df)
-
         commit_map: CommitMap = self.plot_kwargs['get_cmap']()
+        unique_revisions = _get_unique_revisions(
+            interaction_plot_df, commit_map
+        )
         highest_degree = interaction_plot_df["degree"].max()
 
         # Generate and save sankey plots for all revs if no revision was

--- a/varats/varats/plots/blame_interaction_degree.py
+++ b/varats/varats/plots/blame_interaction_degree.py
@@ -175,7 +175,9 @@ def _generate_stackplot(
     fig.subplots_adjust(top=0.95, hspace=0.05, right=0.95, left=0.07)
     fig.suptitle(plot_cfg["fig_suptitle"], fontsize=8)
 
-    unique_rev_strings: tp.List[str] = [rev.hash for rev in unique_revisions]
+    unique_rev_strings: tp.List[str] = [
+        rev.short_hash for rev in unique_revisions
+    ]
     main_axis.stackplot(
         unique_rev_strings,
         sub_df_list,

--- a/varats/varats/plots/repository_churn.py
+++ b/varats/varats/plots/repository_churn.py
@@ -110,7 +110,7 @@ def build_revisions_churn_table(
     code_churn = [(0, 0, 0)]
     code_churn.extend([
         calc_code_churn(
-            repo, repo.get(a), repo.get(b),
+            repo, repo.get(a.hash), repo.get(b.hash),
             ChurnConfig.create_c_style_languages_config()
         ) for a, b in revision_pairs
     ])
@@ -201,7 +201,7 @@ def draw_code_churn_for_revisions(
         project_name, commit_map, revisions
     )
     revisions = churn_data.time_id.astype(str) + '-' + churn_data.revision.map(
-        lambda x: x[:10]
+        lambda x: x.hash[:10]
     )
     clipped_insertions = [
         x if x < CODE_CHURN_INSERTION_LIMIT else 1.3 *

--- a/varats/varats/plots/repository_churn.py
+++ b/varats/varats/plots/repository_churn.py
@@ -200,6 +200,13 @@ def draw_code_churn_for_revisions(
     churn_data = build_revisions_churn_table(
         project_name, commit_map, revisions
     )
+
+    # TODO: Fix duplicated revisions on x-axis caused by the prepended
+    #  time_id when the code_churn is activated. Relates to
+    #  https://github.com/se-sic/VaRA-Tool-Suite/pull/453
+
+    # TODO: Move shown revision length to PlotConfig with length=10 as
+    #  default. Relates to https://github.com/se-sic/VaRA-Tool-Suite/pull/453
     revisions = churn_data.time_id.astype(str) + '-' + churn_data.revision.map(
         lambda x: x.hash[:10]
     )

--- a/varats/varats/plots/repository_churn.py
+++ b/varats/varats/plots/repository_churn.py
@@ -158,7 +158,7 @@ def draw_code_churn(
     code_churn = sort_df(code_churn)
 
     revisions = code_churn.time_id.astype(str) + '-' + code_churn.revision.map(
-        lambda x: x[:10]
+        lambda x: x
     )
     clipped_insertions = [
         x if x < CODE_CHURN_INSERTION_LIMIT else 1.3 *
@@ -200,13 +200,6 @@ def draw_code_churn_for_revisions(
     churn_data = build_revisions_churn_table(
         project_name, commit_map, revisions
     )
-
-    # TODO: Fix duplicated revisions on x-axis caused by the prepended
-    #  time_id when the code_churn is activated. Relates to
-    #  https://github.com/se-sic/VaRA-Tool-Suite/pull/453
-
-    # TODO: Move shown revision length to PlotConfig with length=10 as
-    #  default. Relates to https://github.com/se-sic/VaRA-Tool-Suite/pull/453
     revisions = churn_data.time_id.astype(str) + '-' + churn_data.revision.map(
         lambda x: x.short_hash
     )

--- a/varats/varats/plots/repository_churn.py
+++ b/varats/varats/plots/repository_churn.py
@@ -4,7 +4,6 @@ Generate plots to visualize code churn of a software repository.
 For code churn, we only consider changes in source files.
 """
 import typing as tp
-import warnings
 from itertools import islice
 
 import matplotlib.pyplot as plt
@@ -224,9 +223,8 @@ def draw_code_churn_for_revisions(
     revisions = churn_data.time_id.astype(str) + '-' + churn_data.revision.map(
         lambda x: x.short_hash
     )
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-        axis.set_xticklabels(revisions)
+    axis.set_xticks(axis.get_xticks())
+    axis.set_xticklabels(revisions)
 
 
 class RepoChurnPlot(Plot):

--- a/varats/varats/plots/repository_churn.py
+++ b/varats/varats/plots/repository_churn.py
@@ -208,7 +208,7 @@ def draw_code_churn_for_revisions(
     # TODO: Move shown revision length to PlotConfig with length=10 as
     #  default. Relates to https://github.com/se-sic/VaRA-Tool-Suite/pull/453
     revisions = churn_data.time_id.astype(str) + '-' + churn_data.revision.map(
-        lambda x: x.hash[:10]
+        lambda x: x.short_hash
     )
     clipped_insertions = [
         x if x < CODE_CHURN_INSERTION_LIMIT else 1.3 *

--- a/varats/varats/plots/repository_churn.py
+++ b/varats/varats/plots/repository_churn.py
@@ -4,6 +4,7 @@ Generate plots to visualize code churn of a software repository.
 For code churn, we only consider changes in source files.
 """
 import typing as tp
+import warnings
 from itertools import islice
 
 import matplotlib.pyplot as plt
@@ -197,11 +198,9 @@ def draw_code_churn_for_revisions(
         commit_map: CommitMap for the given project(by project_name)
         revisions: list of revisions used to calculate the churn data
     """
+
     churn_data = build_revisions_churn_table(
         project_name, commit_map, revisions
-    )
-    revisions = churn_data.time_id.astype(str) + '-' + churn_data.revision.map(
-        lambda x: x.short_hash
     )
     clipped_insertions = [
         x if x < CODE_CHURN_INSERTION_LIMIT else 1.3 *
@@ -211,6 +210,7 @@ def draw_code_churn_for_revisions(
         -x if x < CODE_CHURN_DELETION_LIMIT else -1.3 *
         CODE_CHURN_DELETION_LIMIT for x in churn_data.deletions
     ]
+    revisions: tp.List[str] = [rev.short_hash for rev in revisions]
 
     axis.set_ylim(-CODE_CHURN_DELETION_LIMIT, CODE_CHURN_INSERTION_LIMIT)
     axis.fill_between(revisions, clipped_insertions, 0, facecolor='green')
@@ -221,6 +221,12 @@ def draw_code_churn_for_revisions(
         0,
         facecolor='red'
     )
+    revisions = churn_data.time_id.astype(str) + '-' + churn_data.revision.map(
+        lambda x: x.short_hash
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        axis.set_xticklabels(revisions)
 
 
 class RepoChurnPlot(Plot):

--- a/varats/varats/plots/repository_churn.py
+++ b/varats/varats/plots/repository_churn.py
@@ -157,9 +157,8 @@ def draw_code_churn(
 
     code_churn = sort_df(code_churn)
 
-    revisions = code_churn.time_id.astype(str) + '-' + code_churn.revision.map(
-        lambda x: x
-    )
+    revisions = code_churn.time_id.astype(str) + '-' + code_churn.revision
+
     clipped_insertions = [
         x if x < CODE_CHURN_INSERTION_LIMIT else 1.3 *
         CODE_CHURN_INSERTION_LIMIT for x in code_churn.insertions


### PR DESCRIPTION
Starts the replacement of revision strings with `CommitHash` types by adapting the databases and the `interaction_degree_plot` as first plot. Further adaptations will be performed in the PlotRework PR (https://github.com/se-sic/VaRA-Tool-Suite/pull/453) or in one of its sub-PRs.
The current state is that most plots are broken, which should be resolved after the PlotRework PR is merged.