### PR TITLE
Remove passing of explicit generator plot_kwargs

### DIFF
--- a/varats/varats/plots/blame_interaction_degree.py
+++ b/varats/varats/plots/blame_interaction_degree.py
@@ -1542,10 +1542,8 @@ class SankeyLibraryInteractionsGeneratorRev(
         c_map: CommitMap = get_commit_map(
             self.plot_kwargs["case_study"].project_name
         )
-        self.plot_kwargs.update(
-            revision=c_map.convert_to_full_or_warn(
-                ShortCommitHash(self.plot_kwargs["revision"])
-            )
+        self.plot_kwargs["revision"] = c_map.convert_to_full_or_warn(
+            ShortCommitHash(self.plot_kwargs["revision"])
         )
         return [BlameLibraryInteractions(self.plot_config, **self.plot_kwargs)]
 
@@ -1640,10 +1638,8 @@ class GraphvizLibraryInteractionsGeneratorRev(
         c_map: CommitMap = get_commit_map(
             self.plot_kwargs["case_study"].project_name
         )
-        self.plot_kwargs.update(
-            revision=c_map.convert_to_full_or_warn(
-                ShortCommitHash(self.plot_kwargs["revision"])
-            )
+        self.plot_kwargs["revision"] = c_map.convert_to_full_or_warn(
+            ShortCommitHash(self.plot_kwargs["revision"])
         )
         return [
             BlameCommitInteractionsGraphviz(

--- a/varats/varats/plots/case_study_overview.py
+++ b/varats/varats/plots/case_study_overview.py
@@ -231,12 +231,4 @@ class CaseStudyOverviewGenerator(
     """Generates a case study overview plot."""
 
     def generate(self) -> tp.List[Plot]:
-        return [
-            CaseStudyOverviewPlot(
-                plot_config=self.plot_config,
-                report_type=self.plot_kwargs["report_type"],
-                case_study=self.plot_kwargs["case_study"],
-                show_blocked=self.plot_kwargs["show_blocked"],
-                show_all_blocked=self.plot_kwargs["show_all_blocked"]
-            )
-        ]
+        return [CaseStudyOverviewPlot(self.plot_config, **self.plot_kwargs)]

--- a/varats/varats/plots/paper_config_overview.py
+++ b/varats/varats/plots/paper_config_overview.py
@@ -273,8 +273,4 @@ class PaperConfigOverviewGenerator(
     """Generates a single pc-overview plot for the current paper config."""
 
     def generate(self) -> tp.List[Plot]:
-        return [
-            PaperConfigOverviewPlot(
-                self.plot_config, report_type=self.plot_kwargs["report_type"]
-            )
-        ]
+        return [PaperConfigOverviewPlot(self.plot_config, **self.plot_kwargs)]


### PR DESCRIPTION
Removes the explicit pass of `plot_kwargs` to plots within their corresponding generator, but passes all `plot_kwargs` instead.
Affected plots/generators: `interaction-degree-plot`, `sankey-plot-rev`, `sankey-plot-cs`, `graphviz-plot-rev`, `graphviz-plot-cs`, `cs-overview-plot`, `pc-overview-plot`