### PR TITLE
Use xz instead of gzip for tutorial

### DIFF
--- a/docs/source/tutorials/running_experiments.rst
+++ b/docs/source/tutorials/running_experiments.rst
@@ -33,9 +33,9 @@ Case studies are managed with the :ref:`vara-cs` tool.
 
 .. code-block:: bash
 
-    vara-cs gen paper_configs/tutorial/ HalfNormalSamplingMethod -p gzip --num-rev 10
+    vara-cs gen paper_configs/tutorial/ HalfNormalSamplingMethod -p xz --num-rev 10
 
-This creates a new case study for the project gzip and includes 10 revisions sampled with a half normal distribution.
+This creates a new case study for the project xz and includes 10 revisions sampled with a half normal distribution.
 
 Run an Experiment
 -----------------


### PR DESCRIPTION
Use xz instead of gzip for tutorial as gzip has lots of version that are blocked and don't work.