### PR TITLE
Extends the ProjectBinaryWrapper by an entry point

### DIFF
--- a/tests/utils/test_git_util.py
+++ b/tests/utils/test_git_util.py
@@ -1,5 +1,6 @@
 """Test VaRA git utilities."""
 import unittest
+from pathlib import Path
 
 from benchbuild.utils.revision_ranges import RevisionRange
 from plumbum import local

--- a/tests/utils/test_git_util.py
+++ b/tests/utils/test_git_util.py
@@ -377,6 +377,21 @@ class TestRevisionBinaryMap(unittest.TestCase):
 
         self.assertIn("Overridden", self.rv_map)
 
+    def test_specification_binaries_with_special_entry_point(self) -> None:
+        """Check if we can add binaries that have a special entry point."""
+        self.rv_map.specify_binary(
+            "build/bin/SingleLocalSimple",
+            BinaryType.EXECUTABLE,
+            override_entry_point="build/bin/OtherSLSEntry"
+        )
+
+        test_query = self.rv_map[ShortCommitHash("745424e3ae")]
+
+        self.assertEqual(
+            "build/bin/OtherSLSEntry", str(test_query[0].entry_point)
+        )
+        self.assertIsInstance(test_query[0].entry_point, Path)
+
     def test_wrong_contains_check(self) -> None:
         """Check if wrong values are correctly shows as not in the map."""
         self.rv_map.specify_binary(

--- a/tests/utils/test_project_util.py
+++ b/tests/utils/test_project_util.py
@@ -12,6 +12,8 @@ from tests.test_utils import test_environment
 from varats.project.project_util import (
     VaraTestRepoSource,
     VaraTestRepoSubmodule,
+    ProjectBinaryWrapper,
+    BinaryType,
 )
 from varats.tools.bb_config import create_new_bb_config
 from varats.utils.settings import create_new_varats_config
@@ -226,3 +228,27 @@ class TestVaraTestRepoSource(unittest.TestCase):
                     f"The project name {project_name} must not contain the "
                     f"dash character."
                 )
+
+
+class TestProjectBinaryWrapper(unittest.TestCase):
+    """Test if we can correctly setup and use the RevisionBinaryMap."""
+
+    def test_execution_of_executable(self) -> None:
+        """Check if we can execute a executable bianries."""
+        binary = ProjectBinaryWrapper("ls", "/bin/ls", BinaryType.EXECUTABLE)
+
+        ret = binary()
+        self.assertIsNotNone(ret)
+        self.assertIsInstance(ret, str)
+
+    def test_execution_of_libraries(self) -> None:
+        """Check if we don't fail when executing a shared/static library."""
+        static_lib_binary = ProjectBinaryWrapper(
+            "ls", "/bin/ls", BinaryType.STATIC_LIBRARY
+        )
+        self.assertIsNone(static_lib_binary())
+
+        shared_lib_binary = ProjectBinaryWrapper(
+            "ls", "/bin/ls", BinaryType.SHARED_LIBRARY
+        )
+        self.assertIsNone(shared_lib_binary())

--- a/varats-core/varats/project/project_util.py
+++ b/varats-core/varats/project/project_util.py
@@ -175,7 +175,7 @@ class ProjectBinaryWrapper():
 
         if binary_type is BinaryType.EXECUTABLE:
             self.__entry_point = entry_point
-            if not self.entry_point:
+            if not self.__entry_point:
                 self.__entry_point = self.path
         else:
             self.__entry_point = None

--- a/varats-core/varats/utils/git_util.py
+++ b/varats-core/varats/utils/git_util.py
@@ -773,22 +773,26 @@ class RevisionBinaryMap(tp.Container[str]):
         """
 
         Args:
-            location: where the binary can be found, relative to the \
+            location: where the binary can be found, relative to the
                       project-source root
             binary_type: the type of binary that is produced
             override_binary_name: overrides the used binary name
-            only_valid_in: additinally specifies a validity range that \
-                           specifies in which revision range this binary is \
+            override_entry_point: overrides the executable entry point
+            only_valid_in: additinally specifies a validity range that
+                           specifies in which revision range this binary is
                            produced
         """
         binary_location_path = Path(location)
         binary_name: str = kwargs.get(
             "override_binary_name", binary_location_path.stem
         )
+        override_entry_point = kwargs.get("override_entry_point", None)
+        if override_entry_point:
+            override_entry_point = Path(override_entry_point)
         validity_range = kwargs.get("only_valid_in", None)
 
         wrapped_binary = ProjectBinaryWrapper(
-            binary_name, binary_location_path, binary_type
+            binary_name, binary_location_path, binary_type, override_entry_point
         )
 
         if validity_range:

--- a/varats/varats/projects/c_projects/xz.py
+++ b/varats/varats/projects/c_projects/xz.py
@@ -82,6 +82,7 @@ class Xz(VProject):
         binary_map.specify_binary(
             'src/xz/.libs/xz',
             BinaryType.EXECUTABLE,
+            override_entry_point='src/xz/xz',
             only_valid_in=RevisionRange("880c330938", "master")
         )
 


### PR DESCRIPTION
The new entry point specifies which callable should be called to execute
the wrapped binary. The entry point can be overwritten to allow for
cases where the actual binary is not the entry point to call.