### PR TITLE
Implement subscription operator for ProjectBinaryWrapper

### DIFF
--- a/varats-core/varats/project/project_util.py
+++ b/varats-core/varats/project/project_util.py
@@ -210,6 +210,14 @@ class ProjectBinaryWrapper():
         executable_entry_point = local[f"{self.entry_point}"]
         return executable_entry_point(*args, **kwargs)
 
+    def __getitem__(self, args: tp.Any) -> tp.Any:
+        if self.type is not BinaryType.EXECUTABLE:
+            LOG.warning(f"Executing {self.type} is not possible.")
+            return None
+
+        executable_entry_point = local[f"{self.entry_point}"]
+        return executable_entry_point[args]
+
     def __str__(self) -> str:
         return f"{self.name}: {self.path} | {str(self.type)}"
 

--- a/varats-core/varats/project/project_util.py
+++ b/varats-core/varats/project/project_util.py
@@ -213,8 +213,7 @@ class ProjectBinaryWrapper():
 
     def __getitem__(self, args: tp.Any) -> BoundCommand:
         if self.type is not BinaryType.EXECUTABLE:
-            LOG.warning(f"Executing {self.type} is not possible.")
-            return None
+            raise AssertionError(f"Executing {self.type} is not possible.")
 
         executable_entry_point = local[f"{self.entry_point}"]
         return executable_entry_point[args]

--- a/varats-core/varats/project/project_util.py
+++ b/varats-core/varats/project/project_util.py
@@ -13,6 +13,7 @@ from benchbuild.source import Git, GitSubmodule
 from benchbuild.source.base import target_prefix
 from benchbuild.utils.cmd import git, mkdir, cp
 from plumbum import local
+from plumbum.commands.base import BoundCommand
 
 LOG = logging.getLogger(__name__)
 
@@ -210,7 +211,7 @@ class ProjectBinaryWrapper():
         executable_entry_point = local[f"{self.entry_point}"]
         return executable_entry_point(*args, **kwargs)
 
-    def __getitem__(self, args: tp.Any) -> tp.Any:
+    def __getitem__(self, args: tp.Any) -> BoundCommand:
         if self.type is not BinaryType.EXECUTABLE:
             LOG.warning(f"Executing {self.type} is not possible.")
             return None


### PR DESCRIPTION
Matching to the call operator, ProjectBinaryWrapper now offers an
subscription operator that behaves exactly like a plumbum command would,
i.e., returning a BoundCommand to the entry_point).