### PR TITLE
Implement vara-cs cleanup all

### DIFF
--- a/tests/tools/test_driver_casestudy.py
+++ b/tests/tools/test_driver_casestudy.py
@@ -208,7 +208,7 @@ class TestDriverCaseStudy(unittest.TestCase):
         self.assertEqual(
             0, result.exit_code,
             result.stdout + vara_cfg()["paper_config"]["current_config"].value +
-            str(vara_cfg()["config_file"]) + paper_config.path
+            str(vara_cfg()["config_file"]) + paper_config.path.__str__()
         )
         self.assertFalse(
             Path(

--- a/tests/tools/test_driver_casestudy.py
+++ b/tests/tools/test_driver_casestudy.py
@@ -242,6 +242,7 @@ class TestDriverCaseStudy(unittest.TestCase):
         vara_cfg()["paper_config"]["current_config"] = "test_cleanup_regex"
         save_config()
         load_paper_config()
+        importlib.reload(driver_casestudy)
         result = runner.invoke(
             driver_casestudy.main, ['cleanup', 'regex', '-f', '.*'], 'y'
         )

--- a/tests/tools/test_driver_casestudy.py
+++ b/tests/tools/test_driver_casestudy.py
@@ -50,6 +50,7 @@ class TestDriverCaseStudy(unittest.TestCase):
         Path(vara_cfg()["paper_config"]["folder"].value + "/" +
              "test_gen").mkdir()
         vara_cfg()["paper_config"]["current_config"] = "test_gen"
+        from varats.tools import driver_casestudy
         result = runner.invoke(
             driver_casestudy.main, [
                 'gen', '-p', 'brotli', 'select_sample', '--num-rev', '10',
@@ -77,6 +78,7 @@ class TestDriverCaseStudy(unittest.TestCase):
         Path(vara_cfg()["paper_config"]["folder"].value + "/" +
              "test_gen").mkdir()
         vara_cfg()["paper_config"]["current_config"] = "test_gen"
+        from varats.tools import driver_casestudy
         result = runner.invoke(
             driver_casestudy.main, [
                 'gen', '-p', 'brotli', 'select_sample', '--num-rev', '6',

--- a/tests/tools/test_driver_casestudy.py
+++ b/tests/tools/test_driver_casestudy.py
@@ -137,9 +137,10 @@ class TestDriverCaseStudy(unittest.TestCase):
         load_paper_config()
 
         result = runner.invoke(
-            driver_casestudy.main, ['cleanup', 'all', '--error']
+            driver_casestudy.main, ['cleanup', 'all', '--error'],
+            catch_exceptions=False
         )
-        self.assertEqual(0, result.exit_code, result.exception)
+        self.assertEqual(0, result.exit_code, result.stdout)
         self.assertFalse(
             Path(
                 vara_cfg()["result_dir"].value +

--- a/tests/tools/test_driver_casestudy.py
+++ b/tests/tools/test_driver_casestudy.py
@@ -1,5 +1,5 @@
 """Test varats casestudy tool."""
-
+import importlib
 import unittest
 from pathlib import Path
 
@@ -11,7 +11,8 @@ from tests.test_utils import (
     UnitTestInputs,
 )
 from varats.paper.case_study import load_case_study_from_file
-from varats.paper_mgmt.paper_config import load_paper_config, get_paper_config
+from varats.paper_mgmt.paper_config import load_paper_config
+from varats.tools import driver_casestudy
 from varats.utils.git_util import FullCommitHash
 from varats.utils.settings import vara_cfg, save_config
 
@@ -26,7 +27,6 @@ class TestDriverCaseStudy(unittest.TestCase):
         Path(vara_cfg()["paper_config"]["folder"].value + "/" +
              "test_gen").mkdir()
         vara_cfg()["paper_config"]["current_config"] = "test_gen"
-        from varats.tools import driver_casestudy
         result = runner.invoke(
             driver_casestudy.main, [
                 'gen', '-p', 'gravity', 'select_sample',
@@ -50,7 +50,6 @@ class TestDriverCaseStudy(unittest.TestCase):
         Path(vara_cfg()["paper_config"]["folder"].value + "/" +
              "test_gen").mkdir()
         vara_cfg()["paper_config"]["current_config"] = "test_gen"
-        from varats.tools import driver_casestudy
         result = runner.invoke(
             driver_casestudy.main, [
                 'gen', '-p', 'brotli', 'select_sample', '--num-rev', '10',
@@ -78,7 +77,6 @@ class TestDriverCaseStudy(unittest.TestCase):
         Path(vara_cfg()["paper_config"]["folder"].value + "/" +
              "test_gen").mkdir()
         vara_cfg()["paper_config"]["current_config"] = "test_gen"
-        from varats.tools import driver_casestudy
         result = runner.invoke(
             driver_casestudy.main, [
                 'gen', '-p', 'brotli', 'select_sample', '--num-rev', '6',
@@ -112,7 +110,6 @@ class TestDriverCaseStudy(unittest.TestCase):
         Path(vara_cfg()["paper_config"]["folder"].value + "/" +
              "test_gen").mkdir()
         vara_cfg()["paper_config"]["current_config"] = "test_gen"
-        from varats.tools import driver_casestudy
         result = runner.invoke(
             driver_casestudy.main, ['gen', '-p', 'gravity', 'select_latest']
         )
@@ -132,7 +129,6 @@ class TestDriverCaseStudy(unittest.TestCase):
         Path(vara_cfg()["paper_config"]["folder"].value + "/" +
              "test_gen").mkdir()
         vara_cfg()["paper_config"]["current_config"] = "test_gen"
-        from varats.tools import driver_casestudy
         result = runner.invoke(
             driver_casestudy.main, [
                 'gen', '-p', 'gravity', 'select_specific',
@@ -171,7 +167,7 @@ class TestDriverCaseStudy(unittest.TestCase):
         vara_cfg()["paper_config"]["current_config"] = "test_status"
         save_config()
         load_paper_config()
-        from varats.tools import driver_casestudy
+
         result = runner.invoke(driver_casestudy.main, ['status', 'JustCompile'])
         self.assertEqual(0, result.exit_code, result.exception)
         self.assertEqual(
@@ -201,16 +197,11 @@ class TestDriverCaseStudy(unittest.TestCase):
         vara_cfg()["paper_config"]["current_config"] = "test_cleanup_error"
         save_config()
         load_paper_config()
-        paper_config = get_paper_config()
-        from varats.tools import driver_casestudy
+        importlib.reload(driver_casestudy)
         result = runner.invoke(
             driver_casestudy.main, ['cleanup', 'all', '--error']
         )
-        self.assertEqual(
-            0, result.exit_code,
-            result.stdout + vara_cfg()["paper_config"]["current_config"].value +
-            str(vara_cfg()["config_file"]) + paper_config.path.__str__()
-        )
+        self.assertEqual(0, result.exit_code, result.stdout)
         self.assertFalse(
             Path(
                 vara_cfg()["result_dir"].value +
@@ -251,7 +242,6 @@ class TestDriverCaseStudy(unittest.TestCase):
         vara_cfg()["paper_config"]["current_config"] = "test_cleanup_regex"
         save_config()
         load_paper_config()
-        from varats.tools import driver_casestudy
         result = runner.invoke(
             driver_casestudy.main, ['cleanup', 'regex', '-f', '.*'], 'y'
         )

--- a/tests/tools/test_driver_casestudy.py
+++ b/tests/tools/test_driver_casestudy.py
@@ -136,7 +136,9 @@ class TestDriverCaseStudy(unittest.TestCase):
         save_config()
         load_paper_config()
 
-        result = runner.invoke(driver_casestudy.main, ['cleanup', 'error'])
+        result = runner.invoke(
+            driver_casestudy.main, ['cleanup', 'all', '--error']
+        )
         self.assertEqual(0, result.exit_code, result.exception)
         self.assertFalse(
             Path(

--- a/tests/tools/test_driver_casestudy.py
+++ b/tests/tools/test_driver_casestudy.py
@@ -135,10 +135,8 @@ class TestDriverCaseStudy(unittest.TestCase):
         vara_cfg()["paper_config"]["current_config"] = "test_cleanup_error"
         save_config()
         load_paper_config()
-
         result = runner.invoke(
-            driver_casestudy.main, ['cleanup', 'all', '--error'],
-            catch_exceptions=False
+            driver_casestudy.main, ['cleanup', 'all', '--error']
         )
         self.assertEqual(0, result.exit_code, result.stdout)
         self.assertFalse(

--- a/tests/tools/test_driver_casestudy.py
+++ b/tests/tools/test_driver_casestudy.py
@@ -208,7 +208,7 @@ class TestDriverCaseStudy(unittest.TestCase):
         self.assertEqual(
             0, result.exit_code,
             result.stdout + vara_cfg()["paper_config"]["current_config"].value +
-            str(vara_cfg()["config_file"] + paper_config.path)
+            str(vara_cfg()["config_file"]) + paper_config.path
         )
         self.assertFalse(
             Path(

--- a/tests/tools/test_driver_casestudy.py
+++ b/tests/tools/test_driver_casestudy.py
@@ -12,7 +12,6 @@ from tests.test_utils import (
 )
 from varats.paper.case_study import load_case_study_from_file
 from varats.paper_mgmt.paper_config import load_paper_config
-from varats.tools import driver_casestudy
 from varats.utils.git_util import FullCommitHash
 from varats.utils.settings import vara_cfg, save_config
 
@@ -27,6 +26,7 @@ class TestDriverCaseStudy(unittest.TestCase):
         Path(vara_cfg()["paper_config"]["folder"].value + "/" +
              "test_gen").mkdir()
         vara_cfg()["paper_config"]["current_config"] = "test_gen"
+        from varats.tools import driver_casestudy
         result = runner.invoke(
             driver_casestudy.main, [
                 'gen', '-p', 'gravity', 'select_sample',
@@ -49,6 +49,7 @@ class TestDriverCaseStudy(unittest.TestCase):
         Path(vara_cfg()["paper_config"]["folder"].value + "/" +
              "test_gen").mkdir()
         vara_cfg()["paper_config"]["current_config"] = "test_gen"
+        from varats.tools import driver_casestudy
         result = runner.invoke(
             driver_casestudy.main, ['gen', '-p', 'gravity', 'select_latest']
         )
@@ -68,6 +69,7 @@ class TestDriverCaseStudy(unittest.TestCase):
         Path(vara_cfg()["paper_config"]["folder"].value + "/" +
              "test_gen").mkdir()
         vara_cfg()["paper_config"]["current_config"] = "test_gen"
+        from varats.tools import driver_casestudy
         result = runner.invoke(
             driver_casestudy.main, [
                 'gen', '-p', 'gravity', 'select_specific',
@@ -106,6 +108,7 @@ class TestDriverCaseStudy(unittest.TestCase):
         vara_cfg()["paper_config"]["current_config"] = "test_status"
         save_config()
         load_paper_config()
+        from varats.tools import driver_casestudy
         result = runner.invoke(driver_casestudy.main, ['status', 'JustCompile'])
         self.assertEqual(0, result.exit_code, result.exception)
         self.assertEqual(
@@ -135,6 +138,7 @@ class TestDriverCaseStudy(unittest.TestCase):
         vara_cfg()["paper_config"]["current_config"] = "test_cleanup_error"
         save_config()
         load_paper_config()
+        from varats.tools import driver_casestudy
         result = runner.invoke(
             driver_casestudy.main, ['cleanup', 'all', '--error']
         )
@@ -179,6 +183,7 @@ class TestDriverCaseStudy(unittest.TestCase):
         vara_cfg()["paper_config"]["current_config"] = "test_cleanup_regex"
         save_config()
         load_paper_config()
+        from varats.tools import driver_casestudy
         result = runner.invoke(
             driver_casestudy.main, ['cleanup', 'regex', '-f', '.*'], 'y'
         )

--- a/tests/tools/test_driver_casestudy.py
+++ b/tests/tools/test_driver_casestudy.py
@@ -11,7 +11,7 @@ from tests.test_utils import (
     UnitTestInputs,
 )
 from varats.paper.case_study import load_case_study_from_file
-from varats.paper_mgmt.paper_config import load_paper_config
+from varats.paper_mgmt.paper_config import load_paper_config, get_paper_config
 from varats.utils.git_util import FullCommitHash
 from varats.utils.settings import vara_cfg, save_config
 
@@ -200,7 +200,7 @@ class TestDriverCaseStudy(unittest.TestCase):
         runner = CliRunner()
         vara_cfg()["paper_config"]["current_config"] = "test_cleanup_error"
         save_config()
-        load_paper_config()
+        paper_config = get_paper_config()
         from varats.tools import driver_casestudy
         result = runner.invoke(
             driver_casestudy.main, ['cleanup', 'all', '--error']
@@ -208,7 +208,7 @@ class TestDriverCaseStudy(unittest.TestCase):
         self.assertEqual(
             0, result.exit_code,
             result.stdout + vara_cfg()["paper_config"]["current_config"].value +
-            str(vara_cfg()["config_file"])
+            str(vara_cfg()["config_file"] + paper_config.path)
         )
         self.assertFalse(
             Path(

--- a/tests/tools/test_driver_casestudy.py
+++ b/tests/tools/test_driver_casestudy.py
@@ -200,6 +200,7 @@ class TestDriverCaseStudy(unittest.TestCase):
         runner = CliRunner()
         vara_cfg()["paper_config"]["current_config"] = "test_cleanup_error"
         save_config()
+        load_paper_config()
         paper_config = get_paper_config()
         from varats.tools import driver_casestudy
         result = runner.invoke(

--- a/tests/tools/test_driver_casestudy.py
+++ b/tests/tools/test_driver_casestudy.py
@@ -205,7 +205,11 @@ class TestDriverCaseStudy(unittest.TestCase):
         result = runner.invoke(
             driver_casestudy.main, ['cleanup', 'all', '--error']
         )
-        self.assertEqual(0, result.exit_code, result.stdout)
+        self.assertEqual(
+            0, result.exit_code,
+            result.stdout + vara_cfg()["paper_config"]["current_config"].value +
+            str(vara_cfg()["config_file"])
+        )
         self.assertFalse(
             Path(
                 vara_cfg()["result_dir"].value +

--- a/varats/varats/tools/driver_casestudy.py
+++ b/varats/varats/tools/driver_casestudy.py
@@ -51,6 +51,7 @@ from varats.ts_utils.click_param_types import (
     create_report_type_choice,
     TypedChoice,
     EnumChoice,
+    create_multi_case_study_choice,
 )
 from varats.utils.git_util import ShortCommitHash, FullCommitHash
 from varats.utils.settings import vara_cfg
@@ -194,7 +195,7 @@ def __casestudy_gen(
                 case_study.insert_empty_stage(stage_index)
                 case_study.name_stage(stage_index, merge_stage)
             else:
-                stage_index_opt = case_study\
+                stage_index_opt = case_study \
                     .get_stage_index_by_name(merge_stage)
                 if not stage_index_opt:
                     selected_stage = CSStage(merge_stage)
@@ -637,17 +638,84 @@ def __init_commit_hash(
 
 
 @main.group()
-def cleanup() -> None:
-    """Cleanup report files."""
-    return
+@click.option(
+    "--case_studies",
+    "-cs",
+    type=create_multi_case_study_choice(),
+    default='all',
+    help="Only remove reports for revisions from "
+    "these case studies, defaults to all case "
+    "studies from the current paper config"
+)
+@click.option(
+    "--experiment",
+    "-exp",
+    type=create_experiment_type_choice(),
+    help="Only remove reports that belong to the given experiment"
+)
+@click.option(
+    "--report",
+    type=create_report_type_choice(),
+    help="Only remove reports from the given type."
+)
+@click.pass_context
+def cleanup(
+    ctx: click.Context, case_studies: tp.List[CaseStudy],
+    experiment: tp.Optional[VersionExperiment], report: tp.Optional[BaseReport]
+) -> None:
+    """
+    Cleanup report files.
+
+    If both --experiment and --report the report file has to belong to both
+    """
+
+    ctx.ensure_object(dict)
+    ctx.obj["case_study"] = case_studies
+    ctx.obj["experiment"] = experiment
+    ctx.obj["report"] = report
+
+
+@cleanup.command("all")
+@click.option(
+    "--error", is_flag=True, help="remove only reports from failed experiments"
+)
+@click.pass_context
+def _remove_all_result_files(ctx: click.Context, error: bool):
+    """Remove all report files of the current paper_config."""
+    result_folders = _find_result_dir_paths_of_projects(ctx.obj["case_study"])
+    for folder in result_folders:
+        for res_file in folder.iterdir():
+            report_file = ReportFilename(res_file.name)
+            if not report_file.is_result_file():
+                continue
+            if ctx.obj["experiment"] and not ctx.obj[
+                "experiment"].file_belongs_to_experiment(res_file.name):
+                continue
+            if ctx.obj["report"] and not ctx.obj[
+                "report"].is_correct_report_type(res_file.name):
+                continue
+
+            commit_hash = report_file.commit_hash
+            if any(
+                list(
+                    case_study.has_revision(commit_hash)
+                    for case_study in ctx.obj["case_study"]
+                )
+            ):
+                if error and not (
+                    report_file.has_status_compileerror() or
+                    report_file.has_status_failed()
+                ):
+                    continue
+                res_file.unlink()
 
 
 @cleanup.command("old")
-def _remove_old_result_files() -> None:
+@click.pass_context
+def _remove_old_result_files(ctx: click.Context) -> None:
     """Remove result files of wich a newer version exists."""
-    paper_config = get_paper_config()
     result_dir = Path(str(vara_cfg()['result_dir']))
-    for case_study in paper_config.get_all_case_studies():
+    for case_study in ctx.obj['case_study']:
         old_files: tp.List[Path] = []
         newer_files: tp.Dict[ShortCommitHash, Path] = {}
         result_dir_cs = result_dir / case_study.project_name
@@ -655,6 +723,15 @@ def _remove_old_result_files() -> None:
             continue
         for opt_res_file in result_dir_cs.iterdir():
             report_file = ReportFilename(opt_res_file.name)
+            if not report_file.is_result_file():
+                continue
+            if ctx.obj["experiment"] and not ctx.obj[
+                "experiment"].file_belongs_to_experiment(opt_res_file.name):
+                continue
+            if ctx.obj["report"] and not ctx.obj[
+                "report"].is_correct_report_type(opt_res_file.name):
+                continue
+
             commit_hash = report_file.commit_hash
             if case_study.has_revision(commit_hash):
                 current_file = newer_files.get(commit_hash)
@@ -674,25 +751,6 @@ def _remove_old_result_files() -> None:
                 file.unlink()
 
 
-@cleanup.command("error")
-def _remove_error_result_files() -> None:
-    """Remove error result files."""
-    result_dir_paths = _find_result_dir_paths_of_projects()
-
-    for result_dir_path in result_dir_paths:
-        result_file_names = os.listdir(result_dir_path)
-
-        for result_file_name in result_file_names:
-            report_file_name = ReportFilename(result_file_name)
-            if report_file_name.is_result_file() and (
-                report_file_name.has_status_compileerror() or
-                report_file_name.has_status_failed()
-            ):
-                file = Path(result_dir_path / report_file_name.filename)
-                if file.exists():
-                    file.unlink()
-
-
 @cleanup.command("regex")
 @click.option(
     "--filter-regex",
@@ -704,10 +762,16 @@ def _remove_error_result_files() -> None:
 @click.option(
     "--silent", help="Hide the output of the matching filenames", is_flag=True
 )
-def _remove_result_files_by_regex(regex_filter: str, silent: bool) -> None:
-    """Remove result files based on a given regex filter."""
-    result_dir_paths = _find_result_dir_paths_of_projects()
+@click.pass_context
+def _remove_result_files_by_regex(
+    ctx: click.Context, regex_filter: str, silent: bool
+) -> None:
+    """
+    Remove result files based on a given regex filter.
 
+    Ignores experiment and report filter given to the main command
+    """
+    result_dir_paths = _find_result_dir_paths_of_projects(ctx.obj["case_study"])
     for result_dir_path in result_dir_paths:
         result_file_names = os.listdir(result_dir_path)
         files_to_delete: tp.List[str] = []
@@ -736,13 +800,11 @@ def _remove_result_files_by_regex(regex_filter: str, silent: bool) -> None:
             continue
 
 
-def _find_result_dir_paths_of_projects() -> tp.List[Path]:
+def _find_result_dir_paths_of_projects(case_studies: tp.List[CaseStudy]) -> \
+        tp.List[Path]:
     result_dir_path = Path(vara_cfg()["result_dir"].value)
     existing_paper_config_result_dir_paths = []
-    paper_config = get_paper_config()
-    project_names = [
-        cs.project_name for cs in paper_config.get_all_case_studies()
-    ]
+    project_names = [cs.project_name for cs in case_studies]
     for project_name in project_names:
         path = Path(result_dir_path / project_name)
         if Path.exists(path):

--- a/varats/varats/tools/driver_casestudy.py
+++ b/varats/varats/tools/driver_casestudy.py
@@ -680,7 +680,7 @@ def cleanup(
     "--error", is_flag=True, help="remove only reports from failed experiments"
 )
 @click.pass_context
-def _remove_all_result_files(ctx: click.Context, error: bool):
+def _remove_all_result_files(ctx: click.Context, error: bool) -> None:
     """Remove all report files of the current paper_config."""
     result_folders = _find_result_dir_paths_of_projects(ctx.obj["case_study"])
     for folder in result_folders:

--- a/varats/varats/tools/driver_casestudy.py
+++ b/varats/varats/tools/driver_casestudy.py
@@ -682,7 +682,7 @@ def cleanup(
 @click.pass_context
 def _remove_all_result_files(ctx: click.Context, error: bool) -> None:
     """Remove all report files of the current paper_config."""
-    result_folders = _find_result_dir_paths_of_projects(ctx.obj["case_study"])
+    result_folders = _find_result_dir_paths_of_projects(ctx.obj["case_studies"])
     for folder in result_folders:
         for res_file in folder.iterdir():
             report_file = ReportFilename(res_file.name)

--- a/varats/varats/tools/driver_casestudy.py
+++ b/varats/varats/tools/driver_casestudy.py
@@ -670,7 +670,7 @@ def cleanup(
     """
 
     ctx.ensure_object(dict)
-    ctx.obj["case_study"] = case_studies
+    ctx.obj["case_studies"] = case_studies
     ctx.obj["experiment"] = experiment
     ctx.obj["report"] = report
 
@@ -699,7 +699,7 @@ def _remove_all_result_files(ctx: click.Context, error: bool) -> None:
             if any(
                 list(
                     case_study.has_revision(commit_hash)
-                    for case_study in ctx.obj["case_study"]
+                    for case_study in ctx.obj["case_studies"]
                 )
             ):
                 if error and not (
@@ -715,7 +715,7 @@ def _remove_all_result_files(ctx: click.Context, error: bool) -> None:
 def _remove_old_result_files(ctx: click.Context) -> None:
     """Remove result files of wich a newer version exists."""
     result_dir = Path(str(vara_cfg()['result_dir']))
-    for case_study in ctx.obj['case_study']:
+    for case_study in ctx.obj['case_studies']:
         old_files: tp.List[Path] = []
         newer_files: tp.Dict[ShortCommitHash, Path] = {}
         result_dir_cs = result_dir / case_study.project_name
@@ -771,7 +771,9 @@ def _remove_result_files_by_regex(
 
     Ignores experiment and report filter given to the main command
     """
-    result_dir_paths = _find_result_dir_paths_of_projects(ctx.obj["case_study"])
+    result_dir_paths = _find_result_dir_paths_of_projects(
+        ctx.obj["case_studies"]
+    )
     for result_dir_path in result_dir_paths:
         result_file_names = os.listdir(result_dir_path)
         files_to_delete: tp.List[str] = []

--- a/varats/varats/tools/driver_casestudy.py
+++ b/varats/varats/tools/driver_casestudy.py
@@ -639,7 +639,7 @@ def __init_commit_hash(
 
 @main.group()
 @click.option(
-    "--case_studies",
+    "--case-studies",
     "-cs",
     type=create_multi_case_study_choice(),
     default='all',

--- a/varats/varats/ts_utils/click_param_types.py
+++ b/varats/varats/ts_utils/click_param_types.py
@@ -103,8 +103,10 @@ def create_multi_case_study_choice() -> TypedMultiChoice[CaseStudy]:
     """
     try:
         paper_config = get_paper_config()
-    except ConfigurationLookupError:
+    except ConfigurationLookupError as err:
+        print(err)
         empty_cs_dict: tp.Dict[str, tp.List[CaseStudy]] = {}
+
         return TypedMultiChoice(empty_cs_dict)
     value_dict = {
         f"{cs.project_name}_{cs.version}": [cs]

--- a/varats/varats/ts_utils/click_param_types.py
+++ b/varats/varats/ts_utils/click_param_types.py
@@ -101,11 +101,10 @@ def create_multi_case_study_choice() -> TypedMultiChoice[CaseStudy]:
     Multiple case studies can be given as a comma separated list. The special
     value "all" selects all case studies in the current paper config.
     """
-    try:
-        paper_config = get_paper_config()
-    except ConfigurationLookupError:
-        empty_cs_dict: tp.Dict[str, tp.List[CaseStudy]] = {}
-        return TypedMultiChoice(empty_cs_dict)
+    paper_config = get_paper_config()
+    # except ConfigurationLookupError:
+    #     empty_cs_dict: tp.Dict[str, tp.List[CaseStudy]] = {}
+    #     return TypedMultiChoice(empty_cs_dict)
     value_dict = {
         f"{cs.project_name}_{cs.version}": [cs]
         for cs in paper_config.get_all_case_studies()

--- a/varats/varats/ts_utils/click_param_types.py
+++ b/varats/varats/ts_utils/click_param_types.py
@@ -13,7 +13,6 @@ from varats.paper.case_study import CaseStudy
 from varats.paper_mgmt.paper_config import get_paper_config
 from varats.report.report import BaseReport
 from varats.utils.exceptions import ConfigurationLookupError
-from varats.utils.settings import vara_cfg
 
 ChoiceTy = tp.TypeVar("ChoiceTy")
 
@@ -104,17 +103,8 @@ def create_multi_case_study_choice() -> TypedMultiChoice[CaseStudy]:
     """
     try:
         paper_config = get_paper_config()
-    except ConfigurationLookupError as e:
-        empty_cs_dict: tp.Dict[str, tp.List[CaseStudy]] = {
-            e.__str__(): [CaseStudy('gravity', 1)],
-            vara_cfg()["paper_config"]["current_config"].value: [
-                CaseStudy('gravity', 1)
-            ],
-            vara_cfg()["paper_config"]["folder"].value: [
-                CaseStudy('gravity', 1)
-            ],
-            vara_cfg()["config_file"].value: [CaseStudy('gravity', 1)]
-        }
+    except ConfigurationLookupError:
+        empty_cs_dict: tp.Dict[str, tp.List[CaseStudy]] = {}
         return TypedMultiChoice(empty_cs_dict)
     value_dict = {
         f"{cs.project_name}_{cs.version}": [cs]

--- a/varats/varats/ts_utils/click_param_types.py
+++ b/varats/varats/ts_utils/click_param_types.py
@@ -101,8 +101,11 @@ def create_multi_case_study_choice() -> TypedMultiChoice[CaseStudy]:
     Multiple case studies can be given as a comma separated list. The special
     value "all" selects all case studies in the current paper config.
     """
-    paper_config = get_paper_config()
-
+    try:
+        paper_config = get_paper_config()
+    except ConfigurationLookupError:
+        empty_cs_dict: tp.Dict[str, tp.List[CaseStudy]] = {}
+        return TypedMultiChoice(empty_cs_dict)
     value_dict = {
         f"{cs.project_name}_{cs.version}": [cs]
         for cs in paper_config.get_all_case_studies()

--- a/varats/varats/ts_utils/click_param_types.py
+++ b/varats/varats/ts_utils/click_param_types.py
@@ -101,10 +101,11 @@ def create_multi_case_study_choice() -> TypedMultiChoice[CaseStudy]:
     Multiple case studies can be given as a comma separated list. The special
     value "all" selects all case studies in the current paper config.
     """
-    paper_config = get_paper_config()
-    # except ConfigurationLookupError:
-    #     empty_cs_dict: tp.Dict[str, tp.List[CaseStudy]] = {}
-    #     return TypedMultiChoice(empty_cs_dict)
+    try:
+        paper_config = get_paper_config()
+    except ConfigurationLookupError:
+        empty_cs_dict: tp.Dict[str, tp.List[CaseStudy]] = {}
+        return TypedMultiChoice(empty_cs_dict)
     value_dict = {
         f"{cs.project_name}_{cs.version}": [cs]
         for cs in paper_config.get_all_case_studies()

--- a/varats/varats/ts_utils/click_param_types.py
+++ b/varats/varats/ts_utils/click_param_types.py
@@ -103,10 +103,8 @@ def create_multi_case_study_choice() -> TypedMultiChoice[CaseStudy]:
     """
     try:
         paper_config = get_paper_config()
-    except ConfigurationLookupError as err:
-        print(err)
+    except ConfigurationLookupError:
         empty_cs_dict: tp.Dict[str, tp.List[CaseStudy]] = {}
-
         return TypedMultiChoice(empty_cs_dict)
     value_dict = {
         f"{cs.project_name}_{cs.version}": [cs]

--- a/varats/varats/ts_utils/click_param_types.py
+++ b/varats/varats/ts_utils/click_param_types.py
@@ -13,6 +13,7 @@ from varats.paper.case_study import CaseStudy
 from varats.paper_mgmt.paper_config import get_paper_config
 from varats.report.report import BaseReport
 from varats.utils.exceptions import ConfigurationLookupError
+from varats.utils.settings import vara_cfg
 
 ChoiceTy = tp.TypeVar("ChoiceTy")
 
@@ -105,7 +106,14 @@ def create_multi_case_study_choice() -> TypedMultiChoice[CaseStudy]:
         paper_config = get_paper_config()
     except ConfigurationLookupError as e:
         empty_cs_dict: tp.Dict[str, tp.List[CaseStudy]] = {
-            e.__str__(): [CaseStudy('gravity', 1)]
+            e.__str__(): [CaseStudy('gravity', 1)],
+            vara_cfg()["paper_config"]["current_config"].value: [
+                CaseStudy('gravity', 1)
+            ],
+            vara_cfg()["paper_config"]["folder"].value: [
+                CaseStudy('gravity', 1)
+            ],
+            vara_cfg()["config_file"].value: [CaseStudy('gravity', 1)]
         }
         return TypedMultiChoice(empty_cs_dict)
     value_dict = {

--- a/varats/varats/ts_utils/click_param_types.py
+++ b/varats/varats/ts_utils/click_param_types.py
@@ -101,11 +101,8 @@ def create_multi_case_study_choice() -> TypedMultiChoice[CaseStudy]:
     Multiple case studies can be given as a comma separated list. The special
     value "all" selects all case studies in the current paper config.
     """
-    try:
-        paper_config = get_paper_config()
-    except ConfigurationLookupError:
-        empty_cs_dict: tp.Dict[str, tp.List[CaseStudy]] = {}
-        return TypedMultiChoice(empty_cs_dict)
+    paper_config = get_paper_config()
+
     value_dict = {
         f"{cs.project_name}_{cs.version}": [cs]
         for cs in paper_config.get_all_case_studies()

--- a/varats/varats/ts_utils/click_param_types.py
+++ b/varats/varats/ts_utils/click_param_types.py
@@ -103,8 +103,10 @@ def create_multi_case_study_choice() -> TypedMultiChoice[CaseStudy]:
     """
     try:
         paper_config = get_paper_config()
-    except ConfigurationLookupError:
-        empty_cs_dict: tp.Dict[str, tp.List[CaseStudy]] = {}
+    except ConfigurationLookupError as e:
+        empty_cs_dict: tp.Dict[str, tp.List[CaseStudy]] = {
+            e.__str__(): [CaseStudy('gravity', 1)]
+        }
         return TypedMultiChoice(empty_cs_dict)
     value_dict = {
         f"{cs.project_name}_{cs.version}": [cs]


### PR DESCRIPTION
Implement new sub command `all` for `vara-cs cleanup`  
Add options `--experiment`, `--case-studies` and `--report` to the base command to better filter which reports are deleted
Remove subcommand `error` this functionality is now provided by a `--error` flag for the `all` subcommand.
Close se-sic/VaRA#844