### PR TITLE
Add possibility to attach converters to CLI options.

### DIFF
--- a/varats/varats/plot/plots.py
+++ b/varats/varats/plot/plots.py
@@ -697,14 +697,14 @@ def _convert_kwargs(
         ]
     }
     kwargs: tp.Dict[str, tp.Any] = {}
-    for k, v in plot_kwargs.items():
-        if k in converter.keys():
+    for key, value in plot_kwargs.items():
+        if key in converter.keys():
             if to_string:
-                kwargs[k] = converter[k].value_to_string(v)
+                kwargs[key] = converter[key].value_to_string(value)
             else:
-                kwargs[k] = converter[k].string_to_value(v)
+                kwargs[key] = converter[key].string_to_value(value)
         else:
-            kwargs[k] = v
+            kwargs[key] = value
     return kwargs
 
 

--- a/varats/varats/plot/plots.py
+++ b/varats/varats/plot/plots.py
@@ -9,11 +9,18 @@ from pathlib import Path
 import click
 
 from varats.paper_mgmt.artefacts import Artefact, ArtefactFileInfo
+from varats.ts_utils.artefact_util import (
+    CaseStudyConverter,
+    ReportTypeConverter,
+)
 from varats.ts_utils.cli_util import (
     make_cli_option,
     CLIOptionTy,
     add_cli_options,
     cli_yn_choice,
+    CLIOptionConverter,
+    CLIOptionWithConverter,
+    convert_value,
 )
 from varats.ts_utils.click_param_types import (
     create_multi_case_study_choice,
@@ -480,21 +487,29 @@ class PlotConfig():
         }
 
 
-REQUIRE_CASE_STUDY: CLIOptionTy = make_cli_option(
-    "-cs",
-    "--case-study",
-    type=create_single_case_study_choice(),
-    required=True,
-    metavar="NAME",
-    help="The case study to use for the plot."
+REQUIRE_CASE_STUDY: CLIOptionTy = convert_value(
+    "case_study", CaseStudyConverter
+)(
+    make_cli_option(
+        "-cs",
+        "--case-study",
+        type=create_single_case_study_choice(),
+        required=True,
+        metavar="NAME",
+        help="The case study to use for the plot."
+    )
 )
-REQUIRE_MULTI_CASE_STUDY: CLIOptionTy = make_cli_option(
-    "-cs",
-    "--case-study",
-    type=create_multi_case_study_choice(),
-    required=True,
-    metavar="NAMES",
-    help="The case study to use for the plot."
+REQUIRE_MULTI_CASE_STUDY: CLIOptionTy = convert_value(
+    "case_study", CaseStudyConverter
+)(
+    make_cli_option(
+        "-cs",
+        "--case-study",
+        type=create_multi_case_study_choice(),
+        required=True,
+        metavar="NAMES",
+        help="The case study to use for the plot."
+    )
 )
 REQUIRE_REVISION: CLIOptionTy = make_cli_option(
     "-rev",
@@ -504,11 +519,15 @@ REQUIRE_REVISION: CLIOptionTy = make_cli_option(
     metavar="SHORT_COMMIT_HASH",
     help="The revision to use for the plot."
 )
-REQUIRE_REPORT_TYPE: CLIOptionTy = make_cli_option(
-    "--report-type",
-    type=create_report_type_choice(),
-    required=True,
-    help="The report type to use for the plot."
+REQUIRE_REPORT_TYPE: CLIOptionTy = convert_value(
+    "report_type", ReportTypeConverter
+)(
+    make_cli_option(
+        "--report-type",
+        type=create_report_type_choice(),
+        required=True,
+        help="The report type to use for the plot."
+    )
 )
 
 
@@ -653,6 +672,42 @@ class PlotGenerator(abc.ABC):
                 plot.save(plot_dir, filetype=common_options.file_type)
 
 
+def _convert_kwargs(
+    plot_generator_type: tp.Type[PlotGenerator],
+    plot_kwargs: tp.Dict[str, tp.Any],
+    to_string: bool = False
+) -> tp.Dict[str, tp.Any]:
+    """
+    Apply conversions to kwargs as specified by plot generator CLI options.
+
+    Args:
+        plot_generator_type: plot generator with CLI option/converter
+                             declarations
+        plot_kwargs: plot kwargs as values or strings
+        to_string: if ``True`` convert to string, otherwise convert to value
+
+    Returns:
+        the kwargs with applied conversions
+    """
+    converter = {
+        decl_converter.name: decl_converter.converter for decl_converter in [
+            tp.cast(CLIOptionWithConverter[tp.Any], cli_decl)
+            for cli_decl in plot_generator_type.OPTIONS
+            if isinstance(cli_decl, CLIOptionWithConverter)
+        ]
+    }
+    kwargs: tp.Dict[str, tp.Any] = {}
+    for k, v in plot_kwargs.items():
+        if k in converter.keys():
+            if to_string:
+                kwargs[k] = converter[k].value_to_string(v)
+            else:
+                kwargs[k] = converter[k].string_to_value(v)
+        else:
+            kwargs[k] = v
+    return kwargs
+
+
 class PlotArtefact(Artefact, artefact_type="plot", artefact_type_version=2):
     """
     An artefact defining a :class:`~varats.plot.plot.Plot`.
@@ -722,7 +777,9 @@ class PlotArtefact(Artefact, artefact_type="plot", artefact_type_version=2):
         artefact_dict['plot_config'] = self.__plot_config.get_dict()
         artefact_dict = {
             **self.__common_options.get_dict(),
-            **self.__plot_kwargs,
+            **_convert_kwargs(
+                self.plot_generator_class, self.__plot_kwargs, to_string=True
+            ),
             **artefact_dict
         }
         artefact_dict.pop("plot_dir")  # duplicate of Artefact's output_path
@@ -750,7 +807,12 @@ class PlotArtefact(Artefact, artefact_type="plot", artefact_type_version=2):
         )
         return PlotArtefact(
             name, output_dir, plot_generator_type, common_options, plot_config,
-            **kwargs
+            **_convert_kwargs(
+                PlotGenerator.
+                get_class_for_plot_generator_type(plot_generator_type),
+                kwargs,
+                to_string=False
+            )
         )
 
     @staticmethod

--- a/varats/varats/ts_utils/artefact_util.py
+++ b/varats/varats/ts_utils/artefact_util.py
@@ -1,0 +1,55 @@
+import typing as tp
+
+from varats.paper.case_study import CaseStudy
+from varats.paper_mgmt.paper_config import get_loaded_paper_config
+from varats.report.report import BaseReport
+from varats.ts_utils.cli_util import CLIOptionConverter
+
+
+class CaseStudyConverter(CLIOptionConverter[CaseStudy]):
+    """CLI option converter for case studies."""
+
+    @staticmethod
+    def value_to_string(
+        value: tp.Union[CaseStudy, tp.List[CaseStudy]]
+    ) -> tp.Union[str, tp.List[str]]:
+        if isinstance(value, tp.List):
+            pc = get_loaded_paper_config()
+            if value == pc.get_all_case_studies():
+                return "all"
+            return [f"{cs.project_name}_{cs.version}" for cs in value]
+        return f"{value.project_name}_{value.version}"
+
+    @staticmethod
+    def string_to_value(
+        str_value: tp.Union[str, tp.List[str]]
+    ) -> tp.Union[CaseStudy, tp.List[CaseStudy]]:
+        pc = get_loaded_paper_config()
+        if isinstance(str_value, tp.List):
+            return [
+                cs for cs_name in str_value
+                for cs in pc.get_case_studies(cs_name)
+            ]
+        if str_value == "all":
+            return pc.get_all_case_studies()
+        return pc.get_case_studies(str_value)[0]
+
+
+class ReportTypeConverter(CLIOptionConverter[tp.Type[BaseReport]]):
+    """CLI option converter for case studies."""
+
+    @staticmethod
+    def value_to_string(
+        value: tp.Union[tp.Type[BaseReport], tp.List[tp.Type[BaseReport]]]
+    ) -> tp.Union[str, tp.List[str]]:
+        if isinstance(value, tp.List):
+            raise ValueError("Conversion for lists not implemented.")
+        return value.__name__
+
+    @staticmethod
+    def string_to_value(
+        str_value: tp.Union[str, tp.List[str]]
+    ) -> tp.Union[tp.Type[BaseReport], tp.List[tp.Type[BaseReport]]]:
+        if isinstance(str_value, tp.List):
+            raise ValueError("Conversion for lists not implemented.")
+        return BaseReport.REPORT_TYPES[str_value]

--- a/varats/varats/ts_utils/artefact_util.py
+++ b/varats/varats/ts_utils/artefact_util.py
@@ -1,3 +1,4 @@
+"""Utility functions for working with artefacts."""
 import typing as tp
 
 from varats.paper.case_study import CaseStudy

--- a/varats/varats/ts_utils/cli_util.py
+++ b/varats/varats/ts_utils/cli_util.py
@@ -143,6 +143,7 @@ class CLIOptionConverter(abc.ABC, tp.Generic[ConversionTy]):
     def value_to_string(
         value: tp.Union[ConversionTy, tp.List[ConversionTy]]
     ) -> tp.Union[str, tp.List[str]]:
+        """Convert a value to its string representation."""
         ...
 
     @staticmethod
@@ -150,6 +151,7 @@ class CLIOptionConverter(abc.ABC, tp.Generic[ConversionTy]):
     def string_to_value(
         str_value: tp.Union[str, tp.List[str]]
     ) -> tp.Union[ConversionTy, tp.List[ConversionTy]]:
+        """Construct a value from its string representation."""
         ...
 
 

--- a/varats/varats/ts_utils/cli_util.py
+++ b/varats/varats/ts_utils/cli_util.py
@@ -1,5 +1,5 @@
 """Command line utilities."""
-
+import abc
 import logging
 import os
 import sys
@@ -87,7 +87,8 @@ def initialize_logger_config() -> None:
     logging.basicConfig(level=log_level)
 
 
-CLIOptionTy = tp.Callable[..., tp.Any]
+CommandTy = tp.Union[tp.Callable[..., tp.Any], click.Command]
+CLIOptionTy = tp.Callable[[CommandTy], CommandTy]
 
 
 def make_cli_option(*param_decls: str, **attrs: tp.Any) -> CLIOptionTy:
@@ -105,8 +106,7 @@ def make_cli_option(*param_decls: str, **attrs: tp.Any) -> CLIOptionTy:
     return click.option(*param_decls, **attrs)
 
 
-def add_cli_options(command: tp.Callable[..., None],
-                    *options: CLIOptionTy) -> tp.Callable[..., None]:
+def add_cli_options(command: CommandTy, *options: CLIOptionTy) -> CommandTy:
     """
     Adds click CLI options to a click command.
 
@@ -122,10 +122,94 @@ def add_cli_options(command: tp.Callable[..., None],
     return command
 
 
+ConversionTy = tp.TypeVar("ConversionTy", bound=tp.Any, covariant=True)
+
+
+class CLIOptionConverter(abc.ABC, tp.Generic[ConversionTy]):
+    """
+    Converter for CLI option declarations.
+
+    Converters are required for CLI options that are converted to complex types
+    by click so that they can still be properly stored in an artefact file.
+    In general, a converter should implement a mapping from the complex type to
+    a string value as it would be provided on the command line.
+
+    A converter can be attached to a CLI option using the function/decorator
+    :func:`convert_value()`.
+    """
+
+    @staticmethod
+    @abc.abstractmethod
+    def value_to_string(
+        value: tp.Union[ConversionTy, tp.List[ConversionTy]]
+    ) -> tp.Union[str, tp.List[str]]:
+        ...
+
+    @staticmethod
+    @abc.abstractmethod
+    def string_to_value(
+        str_value: tp.Union[str, tp.List[str]]
+    ) -> tp.Union[ConversionTy, tp.List[ConversionTy]]:
+        ...
+
+
+class CLIOptionWithConverter(tp.Generic[ConversionTy]):
+    """Wrapper class that associates a converter with a CLI option
+    declaration."""
+
+    def __init__(
+        self, name: str, converter: tp.Type[CLIOptionConverter[ConversionTy]],
+        cli_decl: tp.Callable[..., CLIOptionTy]
+    ):
+        self.__name = name
+        self.__converter = converter
+        self.__cli_decl = cli_decl
+
+    @property
+    def name(self) -> str:
+        return self.__name
+
+    @property
+    def converter(self) -> tp.Type[CLIOptionConverter[ConversionTy]]:
+        return self.__converter
+
+    def __call__(self, *param_decls: str, **attrs: tp.Any) -> CLIOptionTy:
+        return self.__cli_decl(*param_decls, **attrs)
+
+
+def convert_value(
+    name: str, converter: tp.Type[CLIOptionConverter[ConversionTy]]
+) -> tp.Callable[..., CLIOptionTy]:
+    """
+    Decorator for calls to :func:`make_cli_option()` that attaches a converter.
+
+    Converters are required for CLI options that are converted to complex types
+    by click so that they can still be properly stored in an artefact file.
+    In general, a converter should implement a mapping from the complex type to
+    a string value as it would be provided on the command line.
+
+    Args:
+        name: name for the CLI option. This must be the same as the name for the
+              click option that it wraps but with '-' replaced by '_'.
+        converter: the converter that is attached to the option
+
+    Returns:
+        a CLI option declaration that can be used as if it was created by
+        :func:`make_cli_option()`
+    """
+
+    def decorator(
+        cli_decl: tp.Callable[..., CLIOptionTy]
+    ) -> tp.Callable[..., CLIOptionTy]:
+        return CLIOptionWithConverter(name, converter, cli_decl)
+
+    return decorator
+
+
 def tee(process: PlumbumLocalPopen,
         buffered: bool = True) -> tp.Tuple[int, str, str]:
     """
-    Adapted from from plumbum's TEE implementation.
+    Adapted from plumbum's TEE implementation.
 
     Plumbum's TEE does not allow access to the underlying popen object, which we
     need to properly handle keyboard interrupts. Therefore, we just copy the


### PR DESCRIPTION
Converters are required for CLI options that are converted to complex types by click so that they can still be properly stored in an artefact file.