### PR TITLE
Fixes timestamp based revision sampling

### DIFF
--- a/tests/tools/test_driver_casestudy.py
+++ b/tests/tools/test_driver_casestudy.py
@@ -104,6 +104,36 @@ class TestDriverCaseStudy(unittest.TestCase):
         )
 
     @run_in_test_environment()
+    def test_vara_cs_gen_sample_start_before_initial_commit(self):
+        """Check if vara-cs gen select_sample with start timestamp before the
+        initial commit selects the right revisiosn."""
+        runner = CliRunner()
+        Path(vara_cfg()["paper_config"]["folder"].value + "/" +
+             "test_gen").mkdir()
+        vara_cfg()["paper_config"]["current_config"] = "test_gen"
+        result = runner.invoke(
+            driver_casestudy.main, [
+                'gen', '-p', 'brotli', 'select_sample', '--num-rev', '6',
+                '--start', '1991-01-01', '--end', '2013-10-20',
+                'UniformSamplingMethod'
+            ]
+        )
+
+        self.assertEqual(0, result.exit_code, result.exception)
+        case_study_path = Path(
+            vara_cfg()["paper_config"]["folder"].value +
+            "/test_gen/brotli_0.case_study"
+        )
+        self.assertTrue(case_study_path.exists())
+
+        case_study = load_case_study_from_file(case_study_path)
+        self.assertEqual(len(case_study.revisions), 1)
+        self.assertTrue(
+            FullCommitHash('e0346c826249368f0f4a68a2b95f4ab5cf1e235b') in
+            case_study.revisions
+        )
+
+    @run_in_test_environment()
     def test_vara_cs_gen_latest(self):
         """Test for vara-cs gen select_latest."""
         runner = CliRunner()

--- a/varats/varats/tools/driver_casestudy.py
+++ b/varats/varats/tools/driver_casestudy.py
@@ -54,6 +54,7 @@ from varats.ts_utils.click_param_types import (
     create_multi_case_study_choice,
 )
 from varats.utils.git_util import (
+    get_initial_commit,
     is_commit_hash,
     get_commits_before_timestamp,
     ShortCommitHash,
@@ -310,7 +311,11 @@ def __gen_sample(
         end = get_commits_before_timestamp(end, project_repo_path)[0].hash
 
     if start is not None and not is_commit_hash(start):
-        start = get_commits_before_timestamp(start, project_repo_path)[0].hash
+        commits_before = get_commits_before_timestamp(start, project_repo_path)
+        if commits_before:
+            start = commits_before[0].hash
+        else:
+            start = get_initial_commit(project_repo_path).hash
 
     cmap = create_lazy_commit_map_loader(ctx.obj['project'], None, end, start)()
     extend_with_distrib_sampling(


### PR DESCRIPTION
In cases where the start timestamp is before the initial commit, we
should select the initial commit.