### PR TITLE
Adds utility for automatic zipped report folders

### DIFF
--- a/tests/utils/test_experiment_util.py
+++ b/tests/utils/test_experiment_util.py
@@ -1,9 +1,11 @@
 """Test VaRA Experiment utilities."""
 import os
+import shutil
 import tempfile
 import typing as tp
 import unittest
 import unittest.mock as mock
+from pathlib import Path
 
 import benchbuild.utils.actions as actions
 import benchbuild.utils.settings as s
@@ -255,3 +257,28 @@ class TestVersionExperiment(unittest.TestCase):
         self.assertEqual(sample_gen[0]["test_source"].version, "rev4000000")
         self.assertEqual(len(sample_gen), 1)
         mock_get_tagged_revisions.assert_called()
+
+
+class TestZippedReportFolder(unittest.TestCase):
+    """Test ZippedReportFolder creation."""
+
+    @run_in_test_environment()
+    def test_zipped_result_folder_creation(self):
+        """Checks if a zipped result folder is automatically created."""
+        test_tmp_folder = Path(os.getcwd())
+
+        test_zip = test_tmp_folder / 'FooBar.zip'
+
+        with EU.ZippedReportFolder(test_zip) as output_folder:
+            with open(output_folder / 'foo.txt', 'w') as output_file:
+                output_file.write('content')
+
+        self.assertTrue(test_zip.exists())
+
+        with tempfile.TemporaryDirectory() as tmp_result_dir:
+            shutil.unpack_archive(test_zip, extract_dir=Path(tmp_result_dir))
+
+            should_be_generated_file = Path(tmp_result_dir) / 'foo.txt'
+            self.assertTrue(should_be_generated_file.exists())
+            with open(should_be_generated_file, 'r') as foo_file:
+                self.assertEqual(foo_file.readline(), 'content')

--- a/tests/utils/test_experiment_util.py
+++ b/tests/utils/test_experiment_util.py
@@ -270,7 +270,7 @@ class TestZippedReportFolder(unittest.TestCase):
         test_zip = test_tmp_folder / 'FooBar.zip'
 
         with EU.ZippedReportFolder(test_zip) as output_folder:
-            with open(output_folder / 'foo.txt', 'w') as output_file:
+            with open(Path(output_folder) / 'foo.txt', 'w') as output_file:
                 output_file.write('content')
 
         self.assertTrue(test_zip.exists())

--- a/varats-core/varats/experiment/experiment_util.py
+++ b/varats-core/varats/experiment/experiment_util.py
@@ -8,6 +8,7 @@ import traceback
 import typing as tp
 from abc import abstractmethod
 from pathlib import Path
+from types import TracebackType
 
 from benchbuild import source
 from benchbuild.experiment import Experiment
@@ -476,7 +477,7 @@ def get_tagged_experiment_specific_revisions(
     )
 
 
-class ZippedReportFolder(tempfile.TemporaryDirectory):
+class ZippedReportFolder(tempfile.TemporaryDirectory[str]):
     """
     Context manager for creating a folder report, i.e., a report file which is
     actually a folder containing multiple files and other folders.
@@ -494,7 +495,11 @@ class ZippedReportFolder(tempfile.TemporaryDirectory):
     def __enter__(self) -> Path:
         return Path(super().__enter__())
 
-    def __exit__(self, exc_type, exc_value, exc_traceback) -> None:
+    def __exit__(
+        self, exc_type: tp.Optional[tp.Type[BaseException]],
+        exc_value: tp.Optional[BaseException],
+        exc_traceback: tp.Optional[TracebackType]
+    ) -> None:
         shutil.make_archive(
             str(self.__result_report_name), "zip", Path(self.name)
         )

--- a/varats-core/varats/experiment/experiment_util.py
+++ b/varats-core/varats/experiment/experiment_util.py
@@ -29,7 +29,7 @@ from varats.utils.git_util import ShortCommitHash
 from varats.utils.settings import vara_cfg, bb_cfg
 
 if tp.TYPE_CHECKING:
-    TempDir = tempfile.TemporaryDirectory[Path]
+    TempDir = tempfile.TemporaryDirectory[str]
 else:
     TempDir = tempfile.TemporaryDirectory
 
@@ -496,9 +496,6 @@ class ZippedReportFolder(TempDir):
     def __init__(self, result_report_path: Path) -> None:
         super().__init__()
         self.__result_report_name: Path = result_report_path.with_suffix('')
-
-    def __enter__(self) -> Path:
-        return Path(super().__enter__())
 
     def __exit__(
         self, exc_type: tp.Optional[tp.Type[BaseException]],

--- a/varats-core/varats/experiment/experiment_util.py
+++ b/varats-core/varats/experiment/experiment_util.py
@@ -1,11 +1,13 @@
 """Utility module for BenchBuild experiments."""
 
 import os
+import shutil
 import random
 import traceback
 import typing as tp
 from abc import abstractmethod
 from pathlib import Path
+import tempfile
 
 from benchbuild import source
 from benchbuild.experiment import Experiment
@@ -472,3 +474,28 @@ def get_tagged_experiment_specific_revisions(
     return get_tagged_revisions(
         project_cls, result_file_type, tag_blocked, experiment_filter
     )
+
+
+class ZippedReportFolder(tempfile.TemporaryDirectory):
+    """
+    Context manager for creating a folder report, i.e., a report file which is
+    actually a folder containing multiple files and other folders.
+
+    Example usage: An experiment step can, with this context manager, simply
+        create a folder into which all kinds of data is dropped into. After the
+        completion of the step (leaving the context manager), all files dropped
+        into the folder will be compressed and stored as a single report.
+    """
+
+    def __init__(self, result_report_path: Path) -> None:
+        super().__init__()
+        self.__result_report_name: Path = result_report_path.with_suffix('')
+
+    def __enter__(self) -> Path:
+        return Path(super().__enter__())
+
+    def __exit__(self, exc_type, exc_value, exc_traceback) -> None:
+        shutil.make_archive(
+            str(self.__result_report_name), "zip", Path(self.name)
+        )
+        super().__exit__(exc_type, exc_value, exc_traceback)

--- a/varats-core/varats/experiment/experiment_util.py
+++ b/varats-core/varats/experiment/experiment_util.py
@@ -29,7 +29,7 @@ from varats.utils.git_util import ShortCommitHash
 from varats.utils.settings import vara_cfg, bb_cfg
 
 if tp.TYPE_CHECKING:
-    TempDir = tempfile.TemporaryDirectory[str]
+    TempDir = tempfile.TemporaryDirectory[Path]
 else:
     TempDir = tempfile.TemporaryDirectory
 

--- a/varats-core/varats/experiment/experiment_util.py
+++ b/varats-core/varats/experiment/experiment_util.py
@@ -1,13 +1,13 @@
 """Utility module for BenchBuild experiments."""
 
 import os
-import shutil
 import random
+import shutil
+import tempfile
 import traceback
 import typing as tp
 from abc import abstractmethod
 from pathlib import Path
-import tempfile
 
 from benchbuild import source
 from benchbuild.experiment import Experiment
@@ -482,9 +482,9 @@ class ZippedReportFolder(tempfile.TemporaryDirectory):
     actually a folder containing multiple files and other folders.
 
     Example usage: An experiment step can, with this context manager, simply
-        create a folder into which all kinds of data is dropped into. After the
-        completion of the step (leaving the context manager), all files dropped
-        into the folder will be compressed and stored as a single report.
+    create a folder into which all kinds of data is dropped into. After the
+    completion of the step (leaving the context manager), all files dropped into
+    the folder will be compressed and stored as a single report.
     """
 
     def __init__(self, result_report_path: Path) -> None:

--- a/varats-core/varats/experiment/experiment_util.py
+++ b/varats-core/varats/experiment/experiment_util.py
@@ -28,6 +28,11 @@ from varats.revision.revisions import get_tagged_revisions
 from varats.utils.git_util import ShortCommitHash
 from varats.utils.settings import vara_cfg, bb_cfg
 
+if tp.TYPE_CHECKING:
+    TempDir = tempfile.TemporaryDirectory[str]
+else:
+    TempDir = tempfile.TemporaryDirectory
+
 
 def get_varats_result_folder(project: Project) -> Path:
     """
@@ -477,7 +482,7 @@ def get_tagged_experiment_specific_revisions(
     )
 
 
-class ZippedReportFolder(tempfile.TemporaryDirectory[str]):
+class ZippedReportFolder(TempDir):
     """
     Context manager for creating a folder report, i.e., a report file which is
     actually a folder containing multiple files and other folders.


### PR DESCRIPTION
The new ZippedReportFolder is a context manager with which experiments
can create a folder report, i.e., a folder into which any amount of
files can be dropped into and which is compressed into a single report
file afterwards.