### PR TITLE
Additional verification for VaRA in buildsetup

### DIFF
--- a/varats/varats/tools/driver_build_setup.py
+++ b/varats/varats/tools/driver_build_setup.py
@@ -191,6 +191,11 @@ def build(
             build_type, __get_install_prefix(tool, install_prefix),
             build_folder_suffix
         )
+
+        if not tool.verify_build(build_type, build_folder_suffix):
+            print(f"{tool.name} was not built correctly.")
+            return
+
         if tool.verify_install(__get_install_prefix(tool, install_prefix)):
             print(f"{tool.name} was correctly installed.")
         else:

--- a/varats/varats/tools/research_tools/phasar.py
+++ b/varats/varats/tools/research_tools/phasar.py
@@ -224,6 +224,11 @@ class Phasar(ResearchTool[PhasarCodeBase]):
 
         return status_ok
 
+    def verify_build(
+        self, build_type: BuildType, build_folder_suffix: tp.Optional[str]
+    ) -> bool:
+        return True
+
     def container_add_build_layer(
         self, image_context: 'containers.BaseImageCreationContext'
     ) -> None:

--- a/varats/varats/tools/research_tools/research_tool.py
+++ b/varats/varats/tools/research_tools/research_tool.py
@@ -492,6 +492,17 @@ class ResearchTool(tp.Generic[SpecificCodeBase]):
             True, if the tool was correctly installed
         """
 
+    def verify_build(
+        self, build_type: BuildType, build_folder_suffix: tp.Optional[str]
+    ) -> bool:
+        """
+        Verify if the research tool was built correctly for a given build_type.
+
+        Returns:
+            True, if the build was correct.
+        """
+        return True
+
     def container_install_dependencies(
         self, image_context: 'containers.BaseImageCreationContext'
     ) -> None:

--- a/varats/varats/tools/research_tools/research_tool.py
+++ b/varats/varats/tools/research_tools/research_tool.py
@@ -490,16 +490,21 @@ class ResearchTool(tp.Generic[SpecificCodeBase]):
             True, if the tool was correctly installed
         """
 
+    @abc.abstractmethod
     def verify_build(
         self, build_type: BuildType, build_folder_suffix: tp.Optional[str]
     ) -> bool:
         """
         Verify if the research tool was built correctly for a given build_type.
 
+        Args:
+            build_type: which type of build should be used, e.g., debug,
+                        development or release
+            build_folder_suffix: a suffix that is appended to the build folder
+
         Returns:
             True, if the build was correct.
         """
-        return True
 
     def container_install_dependencies(
         self, image_context: 'containers.BaseImageCreationContext'

--- a/varats/varats/tools/research_tools/szz_unleashed.py
+++ b/varats/varats/tools/research_tools/szz_unleashed.py
@@ -170,6 +170,11 @@ class SZZUnleashed(ResearchTool[SZZUnleashedCodeBase]):
         """
         return (install_location / self.get_jar_name()).exists()
 
+    def verify_build(
+        self, build_type: BuildType, build_folder_suffix: tp.Optional[str]
+    ) -> bool:
+        return True
+
     def container_add_build_layer(
         self, image_context: 'containers.BaseImageCreationContext'
     ) -> None:

--- a/varats/varats/tools/research_tools/vara.py
+++ b/varats/varats/tools/research_tools/vara.py
@@ -5,6 +5,7 @@ import math
 import os
 import re
 import shutil
+import subprocess
 import typing as tp
 from pathlib import Path
 
@@ -375,8 +376,27 @@ class VaRA(ResearchTool[VaRACodeBase]):
         status_ok &= (install_location / "bin/phasar-llvm").exists()
 
         # Check that clang++ can display it's version
-        ProcessManager.create_process(
-            "./bin/clang++", ["--version"], install_location
+        proc = subprocess.run(["./bin/clang++", "--version"],
+                              cwd=install_location,
+                              capture_output=True)
+
+        status_ok &= (proc.returncode == 0)
+        status_ok &= (
+            proc.stdout.find(
+                self.code_base.get_sub_project("vara-llvm-project").url.encode()
+            ) == -1
+        )
+
+        # Check that phasar-llvm can display it's version
+        proc = subprocess.run(["./bin/phasar-llvm", "--version"],
+                              cwd=install_location,
+                              capture_output=True)
+
+        status_ok &= (proc.returncode == 0)
+        status_ok &= (
+            proc.stdout.find(
+                self.code_base.get_sub_project("phasar").name.lower().encode()
+            ) == -1
         )
 
         return status_ok

--- a/varats/varats/tools/research_tools/vara.py
+++ b/varats/varats/tools/research_tools/vara.py
@@ -376,30 +376,58 @@ class VaRA(ResearchTool[VaRACodeBase]):
         status_ok &= (install_location / "bin/phasar-llvm").exists()
 
         # Check that clang++ can display it's version
-        proc = subprocess.run(["./bin/clang++", "--version"],
-                              cwd=install_location,
-                              capture_output=True)
 
-        status_ok &= (proc.returncode == 0)
-        status_ok &= (
-            proc.stdout.find(
-                self.code_base.get_sub_project("vara-llvm-project").url.encode()
-            ) == -1
-        )
+        clang = local[str(install_location / "bin/clang++")]
+
+        (ret, stdout, _) = clang.run("--version")
+
+        vara_name = self.code_base.get_sub_project("vara-llvm-project").name
+        status_ok &= (ret == 0)
+
+        status_ok &= (vara_name in stdout)
 
         # Check that phasar-llvm can display it's version
-        proc = subprocess.run(["./bin/phasar-llvm", "--version"],
-                              cwd=install_location,
-                              capture_output=True)
+        phasar_llvm = local[str(install_location / "bin/phasar-llvm")]
 
-        status_ok &= (proc.returncode == 0)
-        status_ok &= (
-            proc.stdout.find(
-                self.code_base.get_sub_project("phasar").name.lower().encode()
-            ) == -1
-        )
+        (ret, stdout, _) = phasar_llvm.run("--version")
+
+        status_ok &= (ret == 0)
+
+        phasar_name = self.code_base.get_sub_project("phasar").name.lower()
+        status_ok &= (phasar_name in stdout.lower())
+
+        ninja = local["ninja"].with_cwd()
 
         return status_ok
+
+    def verify_build(
+        self, build_type: BuildType, build_folder_suffix: tp.Optional[str]
+    ) -> bool:
+        """
+        Verifies whether vara was built correctly for the given target.
+
+        Args:
+            build_type: which type of build should be used, e.g., debug,
+                        development or release
+
+        Returns:
+            True iff all tests from check_vara pass
+        """
+        full_path = self.code_base.base_dir / "vara-llvm-project" / "build/"
+        if not self.is_build_type_supported(build_type):
+            LOG.critical(
+                f"BuildType {build_type.name} is not supported by VaRA"
+            )
+            return
+
+        build_folder_path = build_type.build_folder(build_folder_suffix)
+        full_path /= build_folder_path
+
+        ninja = local["ninja"].with_cwd(full_path)
+
+        (ret, _, _) = ninja.run("check-vara")
+
+        return ret == 0
 
     def container_install_tool(
         self, image_context: 'containers.BaseImageCreationContext'

--- a/varats/varats/tools/research_tools/vara.py
+++ b/varats/varats/tools/research_tools/vara.py
@@ -375,25 +375,20 @@ class VaRA(ResearchTool[VaRACodeBase]):
         status_ok &= (install_location / "bin/phasar-llvm").exists()
 
         # Check that clang++ can display it's version
-
         clang = local[str(install_location / "bin/clang++")]
-
-        (ret, stdout, _) = clang.run("--version")
+        ret, stdout, _ = clang.run("--version")
 
         vara_name = self.code_base.get_sub_project("vara-llvm-project").name
-        status_ok &= (ret == 0)
-
-        status_ok &= (vara_name in stdout)
+        status_ok &= ret == 0
+        status_ok &= vara_name in stdout
 
         # Check that phasar-llvm can display it's version
         phasar_llvm = local[str(install_location / "bin/phasar-llvm")]
-
-        (ret, stdout, _) = phasar_llvm.run("--version")
-
-        status_ok &= (ret == 0)
+        ret, stdout, _ = phasar_llvm.run("--version")
+        status_ok &= ret == 0
 
         phasar_name = self.code_base.get_sub_project("phasar").name.lower()
-        status_ok &= (phasar_name in stdout.lower())
+        status_ok &= phasar_name in stdout.lower()
 
         return status_ok
 
@@ -421,9 +416,7 @@ class VaRA(ResearchTool[VaRACodeBase]):
         full_path /= build_folder_path
 
         ninja = local["ninja"].with_cwd(full_path)
-
-        (ret, _, _) = ninja.run("check-vara")
-
+        ret, _, _ = ninja.run("check-vara")
         return bool(ret == 0)
 
     def container_install_tool(

--- a/varats/varats/tools/research_tools/vara.py
+++ b/varats/varats/tools/research_tools/vara.py
@@ -5,7 +5,6 @@ import math
 import os
 import re
 import shutil
-import subprocess
 import typing as tp
 from pathlib import Path
 
@@ -396,8 +395,6 @@ class VaRA(ResearchTool[VaRACodeBase]):
         phasar_name = self.code_base.get_sub_project("phasar").name.lower()
         status_ok &= (phasar_name in stdout.lower())
 
-        ninja = local["ninja"].with_cwd()
-
         return status_ok
 
     def verify_build(
@@ -418,7 +415,7 @@ class VaRA(ResearchTool[VaRACodeBase]):
             LOG.critical(
                 f"BuildType {build_type.name} is not supported by VaRA"
             )
-            return
+            return False
 
         build_folder_path = build_type.build_folder(build_folder_suffix)
         full_path /= build_folder_path
@@ -427,7 +424,7 @@ class VaRA(ResearchTool[VaRACodeBase]):
 
         (ret, _, _) = ninja.run("check-vara")
 
-        return ret == 0
+        return bool(ret == 0)
 
     def container_install_tool(
         self, image_context: 'containers.BaseImageCreationContext'

--- a/varats/varats/tools/research_tools/vara.py
+++ b/varats/varats/tools/research_tools/vara.py
@@ -374,6 +374,11 @@ class VaRA(ResearchTool[VaRACodeBase]):
         status_ok &= (install_location / "bin/opt").exists()
         status_ok &= (install_location / "bin/phasar-llvm").exists()
 
+        # Check that clang++ can display it's version
+        ProcessManager.create_process(
+            "./bin/clang++", ["--version"], install_location
+        )
+
         return status_ok
 
     def container_install_tool(


### PR DESCRIPTION
Added additional verification to the `verify_install` step for VaRA

Additionally, VaRA now runs the `check_vara` target to verify that it not only compiles but also passes unittests.

Not sure if we really want this in a separate `verify_build` but in `verify_install` we currently don't have access to the build directory in which we run `ninja`.

resolves https://github.com/se-sic/VaRA/issues/801