### PR TITLE
Avoid unnecessary git fetch and clone calls.

### DIFF
--- a/tests/data/test_diff_correlation_overview_table.py
+++ b/tests/data/test_diff_correlation_overview_table.py
@@ -1,9 +1,7 @@
 """Test the DiffCorrelationOverviewTable class."""
 import unittest
 
-import pytest
-
-from tests.test_utils import run_in_test_environment, UnitTestInputs
+from tests.test_utils import run_in_test_environment, UnitTestFixtures
 from varats.paper_mgmt.paper_config import load_paper_config
 from varats.projects.discover_projects import initialize_projects
 from varats.tables import diff_correlation_overview_table
@@ -13,12 +11,11 @@ from varats.utils.settings import vara_cfg
 class TestDiffCorrelationOverviewTable(unittest.TestCase):
     """Test the DiffCorrelationOverviewTable class."""
 
-    @pytest.mark.slow
     @run_in_test_environment(
-        UnitTestInputs.PAPER_CONFIGS, UnitTestInputs.RESULT_FILES,
-        UnitTestInputs.TABLES
+        UnitTestFixtures.PAPER_CONFIGS, UnitTestFixtures.RESULT_FILES,
+        UnitTestFixtures.TABLES
     )
-    def test_table_tex_output(self):
+    def test_table_tex_output(self) -> None:
         """Check whether the table produces the correct tex output."""
         vara_cfg()["paper_config"]["current_config"
                                   ] = "test_diff_correlation_overview_table"

--- a/tests/paper/test_artefacts.py
+++ b/tests/paper/test_artefacts.py
@@ -4,7 +4,7 @@ import unittest
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 
-from tests.test_utils import run_in_test_environment, UnitTestInputs
+from tests.test_utils import run_in_test_environment, UnitTestFixtures
 from varats.data.reports.empty_report import EmptyReport
 from varats.paper_mgmt.artefacts import (
     initialize_artefact_types,
@@ -121,7 +121,7 @@ class TestArtefacts(unittest.TestCase):
             "paper_config_overview_plot.png", file_infos[0].file_name
         )
 
-    @run_in_test_environment(UnitTestInputs.PAPER_CONFIGS)
+    @run_in_test_environment(UnitTestFixtures.PAPER_CONFIGS)
     def test_cli_option_converter(self):
         """Test whether CLI option conversion works correctly."""
         # setup config

--- a/tests/paper_mgmt/test_case_study.py
+++ b/tests/paper_mgmt/test_case_study.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from pathlib import Path
 
 import varats.paper_mgmt.case_study as MCS
-from tests.test_utils import run_in_test_environment, UnitTestInputs
+from tests.test_utils import run_in_test_environment, UnitTestFixtures
 from varats.data.reports.commit_report import CommitReport as CR
 from varats.paper_mgmt.paper_config import get_paper_config, load_paper_config
 from varats.projects.discover_projects import initialize_projects
@@ -22,7 +22,7 @@ class TestCaseStudyRevisionLookupFunctions(unittest.TestCase):
         initialize_projects()
 
     @run_in_test_environment(
-        UnitTestInputs.PAPER_CONFIGS, UnitTestInputs.RESULT_FILES
+        UnitTestFixtures.PAPER_CONFIGS, UnitTestFixtures.RESULT_FILES
     )
     def test_newest_processed_revision(self) -> None:
         """Check whether the newest processed revision is correctly
@@ -39,7 +39,7 @@ class TestCaseStudyRevisionLookupFunctions(unittest.TestCase):
             newest_processed
         )
 
-    @run_in_test_environment(UnitTestInputs.PAPER_CONFIGS)
+    @run_in_test_environment(UnitTestFixtures.PAPER_CONFIGS)
     def test_newest_processed_revision_no_results(self) -> None:
         """Check None is returned when no results are available."""
         vara_cfg()['paper_config']['current_config'] = "test_revision_lookup"
@@ -52,7 +52,7 @@ class TestCaseStudyRevisionLookupFunctions(unittest.TestCase):
         self.assertIsNone(newest_processed)
 
     @run_in_test_environment(
-        UnitTestInputs.PAPER_CONFIGS, UnitTestInputs.RESULT_FILES
+        UnitTestFixtures.PAPER_CONFIGS, UnitTestFixtures.RESULT_FILES
     )
     def test_get_failed_revisions(self) -> None:
         """Check if we can correctly find all failed revisions of a case
@@ -71,7 +71,7 @@ class TestCaseStudyRevisionLookupFunctions(unittest.TestCase):
         )
 
     @run_in_test_environment(
-        UnitTestInputs.PAPER_CONFIGS, UnitTestInputs.RESULT_FILES
+        UnitTestFixtures.PAPER_CONFIGS, UnitTestFixtures.RESULT_FILES
     )
     def test_get_processed_revisions(self) -> None:
         """Check if we can correctly find all processed revisions of a case
@@ -89,7 +89,7 @@ class TestCaseStudyRevisionLookupFunctions(unittest.TestCase):
             process_revs
         )
 
-    @run_in_test_environment(UnitTestInputs.PAPER_CONFIGS)
+    @run_in_test_environment(UnitTestFixtures.PAPER_CONFIGS)
     def test_get_revisions_status_for_case_study_to_high_stage(self) -> None:
         """Check if we correctly handle look ups where the stage selected is
         larger than the biggest one in the case study."""
@@ -102,7 +102,7 @@ class TestCaseStudyRevisionLookupFunctions(unittest.TestCase):
             ), []
         )
 
-    @run_in_test_environment(UnitTestInputs.PAPER_CONFIGS)
+    @run_in_test_environment(UnitTestFixtures.PAPER_CONFIGS)
     def test_get_revision_not_in_case_study(self) -> None:
         """Check if we correctly handle the lookup of a revision that is not in
         the case study."""
@@ -116,7 +116,7 @@ class TestCaseStudyRevisionLookupFunctions(unittest.TestCase):
         )
 
     @run_in_test_environment(
-        UnitTestInputs.PAPER_CONFIGS, UnitTestInputs.RESULT_FILES
+        UnitTestFixtures.PAPER_CONFIGS, UnitTestFixtures.RESULT_FILES
     )
     def test_get_revisions_in_case_study(self) -> None:
         """Check if we correctly handle the lookup of a revision that is in a
@@ -132,7 +132,7 @@ class TestCaseStudyRevisionLookupFunctions(unittest.TestCase):
         )
 
     @run_in_test_environment(
-        UnitTestInputs.PAPER_CONFIGS, UnitTestInputs.RESULT_FILES
+        UnitTestFixtures.PAPER_CONFIGS, UnitTestFixtures.RESULT_FILES
     )
     def test_get_newest_result_files_for_case_study(self) -> None:
         """Check that when we have two files, the newes one get's selected."""
@@ -168,7 +168,7 @@ class TestCaseStudyRevisionLookupFunctions(unittest.TestCase):
         self.assertTrue(filtered_newest_res_files[0].uuid.endswith('42'))
 
     @run_in_test_environment(
-        UnitTestInputs.PAPER_CONFIGS, UnitTestInputs.RESULT_FILES
+        UnitTestFixtures.PAPER_CONFIGS, UnitTestFixtures.RESULT_FILES
     )
     def test_get_newest_result_files_for_case_study_fail(self) -> None:
         """Check that when we have two files, the newes one get's selected."""
@@ -203,7 +203,7 @@ class TestCaseStudyRevisionLookupFunctions(unittest.TestCase):
 
         self.assertFalse(filtered_newest_res_files[0].uuid.endswith('42'))
 
-    @run_in_test_environment(UnitTestInputs.PAPER_CONFIGS)
+    @run_in_test_environment(UnitTestFixtures.PAPER_CONFIGS)
     def test_get_newest_result_files_for_case_study_with_empty_res_dir(
         self
     ) -> None:

--- a/tests/report/test_blame_interaction_graph.py
+++ b/tests/report/test_blame_interaction_graph.py
@@ -4,7 +4,7 @@ import unittest
 
 import pytest
 
-from tests.test_utils import run_in_test_environment, UnitTestInputs
+from tests.test_utils import run_in_test_environment, UnitTestFixtures
 from varats.data.reports.blame_interaction_graph import (
     create_blame_interaction_graph,
     create_file_based_interaction_graph,
@@ -27,7 +27,7 @@ class TestBlameInteractionGraphs(unittest.TestCase):
         initialize_projects()
 
     @run_in_test_environment(
-        UnitTestInputs.PAPER_CONFIGS, UnitTestInputs.RESULT_FILES
+        UnitTestFixtures.PAPER_CONFIGS, UnitTestFixtures.RESULT_FILES
     )
     def test_blame_interaction_graph(self) -> None:
         """Test whether blame interaction graphs are created correctly."""
@@ -55,7 +55,7 @@ class TestBlameInteractionGraphs(unittest.TestCase):
 
     @pytest.mark.slow
     @run_in_test_environment(
-        UnitTestInputs.PAPER_CONFIGS, UnitTestInputs.RESULT_FILES
+        UnitTestFixtures.PAPER_CONFIGS, UnitTestFixtures.RESULT_FILES
     )
     def test_file_based_interaction_graph(self) -> None:
         """Test whether file-based interaction graphs are created correctly."""
@@ -84,7 +84,7 @@ class TestBlameInteractionGraphs(unittest.TestCase):
         self.assertEqual(509, len(caig.edges))
 
     @run_in_test_environment(
-        UnitTestInputs.PAPER_CONFIGS, UnitTestInputs.RESULT_FILES
+        UnitTestFixtures.PAPER_CONFIGS, UnitTestFixtures.RESULT_FILES
     )
     def test_get_author_data(self) -> None:
         """Check whether author data is retrieved correctly from the author

--- a/tests/table/test_blame_interaction_graph_table.py
+++ b/tests/table/test_blame_interaction_graph_table.py
@@ -1,7 +1,7 @@
 """Test bug overview table."""
 import unittest
 
-from tests.test_utils import run_in_test_environment, UnitTestInputs
+from tests.test_utils import run_in_test_environment, UnitTestFixtures
 from varats.paper_mgmt.paper_config import (
     load_paper_config,
     get_loaded_paper_config,
@@ -21,7 +21,7 @@ class TestCSMetricsTable(unittest.TestCase):
     """Test whether case study metrics are collected correctly."""
 
     @run_in_test_environment(
-        UnitTestInputs.PAPER_CONFIGS, UnitTestInputs.RESULT_FILES
+        UnitTestFixtures.PAPER_CONFIGS, UnitTestFixtures.RESULT_FILES
     )
     def test_cig_metrics_table(self) -> None:
         """Tests the latex booktabs format for the cig metrics table."""
@@ -46,7 +46,7 @@ class TestCSMetricsTable(unittest.TestCase):
         )
 
     @run_in_test_environment(
-        UnitTestInputs.PAPER_CONFIGS, UnitTestInputs.RESULT_FILES
+        UnitTestFixtures.PAPER_CONFIGS, UnitTestFixtures.RESULT_FILES
     )
     def test_aig_metrics_table(self) -> None:
         """Tests the latex booktabs format for the aig metrics table."""
@@ -71,7 +71,7 @@ class TestCSMetricsTable(unittest.TestCase):
         )
 
     @run_in_test_environment(
-        UnitTestInputs.PAPER_CONFIGS, UnitTestInputs.RESULT_FILES
+        UnitTestFixtures.PAPER_CONFIGS, UnitTestFixtures.RESULT_FILES
     )
     def test_caig_metrics_table(self) -> None:
         """Tests the latex booktabs format for the caig metrics table."""
@@ -96,7 +96,7 @@ class TestCSMetricsTable(unittest.TestCase):
         )
 
     @run_in_test_environment(
-        UnitTestInputs.PAPER_CONFIGS, UnitTestInputs.RESULT_FILES
+        UnitTestFixtures.PAPER_CONFIGS, UnitTestFixtures.RESULT_FILES
     )
     def test_aig_file_vs_blame_degrees_table(self) -> None:
         """

--- a/tests/table/test_case_study_metrics_table.py
+++ b/tests/table/test_case_study_metrics_table.py
@@ -1,7 +1,7 @@
 """Test bug overview table."""
 import unittest
 
-from tests.test_utils import run_in_test_environment, UnitTestInputs
+from tests.test_utils import run_in_test_environment, UnitTestFixtures
 from varats.paper_mgmt.paper_config import load_paper_config
 from varats.projects.discover_projects import initialize_projects
 from varats.tables.case_study_metrics_table import CaseStudyMetricsTable
@@ -12,7 +12,7 @@ from varats.utils.settings import vara_cfg
 class TestCSMetricsTable(unittest.TestCase):
     """Test whether case study metrics are collected correctly."""
 
-    @run_in_test_environment(UnitTestInputs.PAPER_CONFIGS)
+    @run_in_test_environment(UnitTestFixtures.PAPER_CONFIGS)
     def test_one_case_study_latex_booktabs(self) -> None:
         """"Tests the latex booktabs format for the cs overview table."""
         vara_cfg()["paper_config"]["current_config"] = "test_revision_lookup"
@@ -38,7 +38,7 @@ class TestCSMetricsTable(unittest.TestCase):
 """, table_str
         )
 
-    @run_in_test_environment(UnitTestInputs.PAPER_CONFIGS)
+    @run_in_test_environment(UnitTestFixtures.PAPER_CONFIGS)
     def test_multiple_case_studies_latex_booktabs(self) -> None:
         """"Tests the latex booktabs format for the cs overview table."""
         vara_cfg()["paper_config"]["current_config"] = "test_artefacts_driver"

--- a/tests/table/test_code_centrality_table.py
+++ b/tests/table/test_code_centrality_table.py
@@ -1,7 +1,7 @@
 """Test bug overview table."""
 import unittest
 
-from tests.test_utils import run_in_test_environment, UnitTestInputs
+from tests.test_utils import run_in_test_environment, UnitTestFixtures
 from varats.paper_mgmt.paper_config import (
     load_paper_config,
     get_loaded_paper_config,
@@ -15,7 +15,7 @@ class TestCSMetricsTable(unittest.TestCase):
     """Test whether case study metrics are collected correctly."""
 
     @run_in_test_environment(
-        UnitTestInputs.PAPER_CONFIGS, UnitTestInputs.RESULT_FILES
+        UnitTestFixtures.PAPER_CONFIGS, UnitTestFixtures.RESULT_FILES
     )
     def test_one_case_study_latex_booktabs(self) -> None:
         """Tests the latex booktabs format for the code centrality metrics

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,6 +2,7 @@
 import contextlib
 import os
 import shutil
+import sys
 import tempfile
 import typing as tp
 from functools import wraps
@@ -20,12 +21,17 @@ from varats.base.configuration import ConfigurationImpl, ConfigurationOptionImpl
 from varats.project.project_util import is_git_source
 from varats.tools.bb_config import create_new_bb_config
 
+if sys.version_info <= (3, 8):
+    from typing_extensions import Protocol
+else:
+    from typing import Protocol
+
 TEST_INPUTS_DIR = Path(os.path.dirname(__file__)) / 'TEST_INPUTS'
 
 TestFunctionTy = tp.Callable[..., tp.Any]
 
 
-class UnitTestFixture(tp.Protocol):
+class UnitTestFixture(Protocol):
     """A test fixture that can be used with a :class:`TestEnvironment`."""
 
     def copy_to_env(self, path: Path) -> None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -61,7 +61,9 @@ class FileFixture(UnitTestFixture):
     def copy_to_env(self, path: Path) -> None:
         dst = path / self.__dst
         if self.__src.is_dir():
-            shutil.copytree(self.__src, dst, dirs_exist_ok=True)
+            if self.__dst.exists():
+                self.__dst.rmdir()
+            shutil.copytree(self.__src, dst)
         else:
             shutil.copy(self.__src, dst)
 

--- a/tests/tools/test_driver_artefacts.py
+++ b/tests/tools/test_driver_artefacts.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 from click.testing import CliRunner
 
-from tests.test_utils import run_in_test_environment, UnitTestInputs
+from tests.test_utils import run_in_test_environment, UnitTestFixtures
 from varats.data.discover_reports import initialize_reports
 from varats.paper_mgmt.artefacts import Artefact
 from varats.paper_mgmt.paper_config import get_paper_config, load_paper_config
@@ -30,7 +30,7 @@ class TestDriverArtefacts(unittest.TestCase):
         initialize_tables()
         initialize_plots()
 
-    @run_in_test_environment(UnitTestInputs.PAPER_CONFIGS)
+    @run_in_test_environment(UnitTestFixtures.PAPER_CONFIGS)
     @mock.patch('varats.table.tables.build_table', side_effect=_mock_table)
     # pylint: disable=unused-argument
     def test_artefacts_generate(self, build_tables):
@@ -59,7 +59,7 @@ class TestDriverArtefacts(unittest.TestCase):
             self.assertTrue((artefact.output_dir / file_info.file_name).exists()
                            )
 
-    @run_in_test_environment(UnitTestInputs.PAPER_CONFIGS)
+    @run_in_test_environment(UnitTestFixtures.PAPER_CONFIGS)
     def test_artefacts_list(self):
         """Test whether `vara-art list` produces expected output."""
 
@@ -76,7 +76,7 @@ class TestDriverArtefacts(unittest.TestCase):
             result.stdout
         )
 
-    @run_in_test_environment(UnitTestInputs.PAPER_CONFIGS)
+    @run_in_test_environment(UnitTestFixtures.PAPER_CONFIGS)
     def test_artefacts_show(self):
         """Test whether `vara-art show` produces expected output."""
 

--- a/tests/tools/test_driver_casestudy.py
+++ b/tests/tools/test_driver_casestudy.py
@@ -8,7 +8,7 @@ from click.testing import CliRunner
 from tests.test_utils import (
     run_in_test_environment,
     TEST_INPUTS_DIR,
-    UnitTestInputs,
+    UnitTestFixtures,
 )
 from varats.paper.case_study import load_case_study_from_file
 from varats.paper_mgmt.paper_config import load_paper_config
@@ -186,7 +186,7 @@ class TestDriverCaseStudy(unittest.TestCase):
         self.assertEqual(len(case_study.revisions), 2)
 
     @run_in_test_environment(
-        UnitTestInputs.create_test_input(
+        UnitTestFixtures.create_file_fixture(
             TEST_INPUTS_DIR / "paper_configs/test_casestudy_status",
             Path("paper_configs/test_status")
         )
@@ -213,10 +213,10 @@ class TestDriverCaseStudy(unittest.TestCase):
         )
 
     @run_in_test_environment(
-        UnitTestInputs.create_test_input(
+        UnitTestFixtures.create_file_fixture(
             TEST_INPUTS_DIR / "results/brotli", Path("results/brotli")
         ),
-        UnitTestInputs.create_test_input(
+        UnitTestFixtures.create_file_fixture(
             TEST_INPUTS_DIR / "paper_configs/test_revision_lookup",
             Path("paper_configs/test_cleanup_error")
         )
@@ -255,13 +255,13 @@ class TestDriverCaseStudy(unittest.TestCase):
         )
 
     @run_in_test_environment(
-        UnitTestInputs.create_test_input(
+        UnitTestFixtures.create_file_fixture(
             TEST_INPUTS_DIR / "results/brotli", Path("results/brotli")
         ),
-        UnitTestInputs.create_test_input(
+        UnitTestFixtures.create_file_fixture(
             TEST_INPUTS_DIR / "results/gravity", Path("results/gravity")
         ),
-        UnitTestInputs.create_test_input(
+        UnitTestFixtures.create_file_fixture(
             TEST_INPUTS_DIR / "paper_configs/test_revision_lookup",
             Path("paper_configs/test_cleanup_regex")
         )

--- a/tests/tools/test_driver_plot.py
+++ b/tests/tools/test_driver_plot.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 from click.testing import CliRunner
 
-from tests.test_utils import run_in_test_environment, UnitTestInputs
+from tests.test_utils import run_in_test_environment, UnitTestFixtures
 from varats.paper_mgmt.paper_config import get_paper_config, load_paper_config
 from varats.plot.plots import PlotArtefact
 from varats.tools import driver_plot
@@ -15,7 +15,7 @@ class TestDriverPlot(unittest.TestCase):
     """Tests for the driver_plot module."""
 
     @run_in_test_environment(
-        UnitTestInputs.PAPER_CONFIGS, UnitTestInputs.RESULT_FILES
+        UnitTestFixtures.PAPER_CONFIGS, UnitTestFixtures.RESULT_FILES
     )
     def test_plot(self):
         """Test whether `vara-plot` generates a plot."""
@@ -37,7 +37,7 @@ class TestDriverPlot(unittest.TestCase):
             (plot_base_dir / "foo" / "paper_config_overview_plot.svg").exists()
         )
 
-    @run_in_test_environment(UnitTestInputs.PAPER_CONFIGS)
+    @run_in_test_environment(UnitTestFixtures.PAPER_CONFIGS)
     def test_store_artefact(self):
         """Test whether `vara-plot` can store artefacts."""
         # setup config

--- a/tests/tools/test_driver_run.py
+++ b/tests/tools/test_driver_run.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from click.testing import CliRunner
 
-from tests.test_utils import run_in_test_environment, UnitTestInputs
+from tests.test_utils import run_in_test_environment, UnitTestFixtures
 from varats.paper_mgmt.paper_config import load_paper_config
 from varats.tools import driver_run, driver_container
 from varats.utils.settings import vara_cfg, save_config, bb_cfg, save_bb_config
@@ -17,7 +17,7 @@ class TestDriverRun(unittest.TestCase):
 
     __NUM_ACTIONS_PATTERN = re.compile(r"Number of actions to execute: (\d*)")
 
-    @run_in_test_environment(UnitTestInputs.PAPER_CONFIGS)
+    @run_in_test_environment(UnitTestFixtures.PAPER_CONFIGS)
     def test_bb_run_select_project(self) -> None:
         runner = CliRunner()
         vara_cfg()['paper_config']['current_config'] = "test_artefacts_driver"
@@ -35,7 +35,7 @@ class TestDriverRun(unittest.TestCase):
             self.fail("Could not parse benchbuild output")
         self.assertEqual("43", match.group(1))
 
-    @run_in_test_environment(UnitTestInputs.PAPER_CONFIGS)
+    @run_in_test_environment(UnitTestFixtures.PAPER_CONFIGS)
     def test_bb_run_select_revision(self) -> None:
         runner = CliRunner()
         vara_cfg()['paper_config']['current_config'] = "test_artefacts_driver"
@@ -53,7 +53,7 @@ class TestDriverRun(unittest.TestCase):
             self.fail("Could not parse benchbuild output")
         self.assertEqual("11", match.group(1))
 
-    @run_in_test_environment(UnitTestInputs.PAPER_CONFIGS)
+    @run_in_test_environment(UnitTestFixtures.PAPER_CONFIGS)
     def test_bb_run_all(self) -> None:
         runner = CliRunner()
         vara_cfg()['paper_config']['current_config'] = "test_artefacts_driver"
@@ -69,7 +69,7 @@ class TestDriverRun(unittest.TestCase):
             self.fail("Could not parse benchbuild output")
         self.assertEqual("51", match.group(1))
 
-    @run_in_test_environment(UnitTestInputs.PAPER_CONFIGS)
+    @run_in_test_environment(UnitTestFixtures.PAPER_CONFIGS)
     @mock.patch("varats.tools.driver_run.sbatch")
     @mock.patch("varats.tools.driver_container.__build_images")
     def test_bb_run_slurm_and_container(

--- a/tests/utils/test_project_util.py
+++ b/tests/utils/test_project_util.py
@@ -1,14 +1,13 @@
 """Test VaRA project utilities."""
 import typing as tp
 import unittest
-import unittest.mock as mock
 from os.path import isdir
 from pathlib import Path
 
 from benchbuild.utils.cmd import git, mkdir
 from plumbum import local
 
-from tests.test_utils import test_environment
+from tests.test_utils import run_in_test_environment, UnitTestFixtures
 from varats.project.project_util import (
     get_project_cls_by_name,
     get_loaded_vara_projects,
@@ -22,7 +21,7 @@ from varats.ts_utils.project_sources import (
     VaraTestRepoSource,
     VaraTestRepoSubmodule,
 )
-from varats.utils.settings import create_new_varats_config
+from varats.utils.settings import create_new_varats_config, bb_cfg
 
 
 class TestProjectLookup(unittest.TestCase):
@@ -60,13 +59,19 @@ class TestVaraTestRepoSource(unittest.TestCase):
     """Test if directories and files of a VaraTestRepoSource and its
     VaraTestRepoSubmodules are correctly set up."""
 
+    revision: tp.ClassVar[str]
+    bb_result_report_path: tp.ClassVar[Path]
+    bb_result_lib_path: tp.ClassVar[Path]
+    elementalist: tp.ClassVar[VaraTestRepoSource]
+    fire_lib: tp.ClassVar[VaraTestRepoSubmodule]
+    water_lib: tp.ClassVar[VaraTestRepoSubmodule]
+
     @classmethod
     def setUp(cls) -> None:
         """Define a multi library example repo."""
 
         cls.revision = "e64923e69e"
 
-        cls.bb_tmp_path = Path("benchbuild/tmp")
         cls.bb_result_report_path = Path(
             "benchbuild/results/GenerateBlameReport"
         )
@@ -111,145 +116,103 @@ class TestVaraTestRepoSource(unittest.TestCase):
             shallow=False,
         )
 
-    @mock.patch('benchbuild.source.base.target_prefix')
-    @mock.patch('varats.ts_utils.project_sources.target_prefix')
-    def test_vara_test_repo_dir_creation(
-        self, mock_tgt_prefix_base, mock_tgt_prefix_project_util
-    ) -> None:
+    @run_in_test_environment(UnitTestFixtures.TEST_PROJECTS)
+    def test_vara_test_repo_dir_creation(self) -> None:
         """Test if the needed directories of the main repo and its submodules
         are present."""
 
-        with test_environment() as tmppath:
-            mock_tgt_prefix_base.return_value = \
-                tmppath / self.bb_tmp_path
-            mock_tgt_prefix_project_util.return_value = \
-                tmppath / self.bb_tmp_path
+        mkdir("-p", self.bb_result_report_path)
 
-            mkdir("-p", self.bb_result_report_path)
-            mkdir(self.bb_tmp_path)
+        self.elementalist.version(
+            f"{self.bb_result_report_path}/"
+            f"TwoLibsOneProjectInteractionDiscreteLibsSingleProject"
+            f"-cpp_projects@{self.revision}",
+            version=self.revision
+        )
 
-            self.elementalist.fetch()
-            self.elementalist.version(
-                self.bb_result_report_path / Path(
-                    f"TwoLibsOneProjectInteractionDiscreteLibsSingle"
-                    f"Project-cpp_projects@{self.revision}",
-                    version=self.revision
-                )
+        # Are directories present?
+        self.assertTrue(
+            isdir(
+                f"{str(bb_cfg()['tmp_dir'])}/"
+                f"TwoLibsOneProjectInteractionDiscreteLibsSingleProject"
             )
+        )
+        self.assertTrue(isdir(self.bb_result_lib_path))
+        self.assertTrue(isdir(self.bb_result_lib_path / "Elementalist"))
+        self.assertTrue(isdir(self.bb_result_lib_path / "fire_lib"))
+        self.assertTrue(isdir(self.bb_result_lib_path / "water_lib"))
+        self.assertTrue(
+            isdir(
+                self.bb_result_lib_path / "Elementalist" / "external" /
+                "fire_lib"
+            )
+        )
+        self.assertTrue(
+            isdir(
+                self.bb_result_lib_path / "Elementalist" / "external" /
+                "water_lib"
+            )
+        )
 
-            # Are directories present?
-            self.assertTrue(
-                isdir(
-                    self.bb_tmp_path /
-                    "TwoLibsOneProjectInteractionDiscreteLibsSingle"
-                    "Project"
-                )
-            )
-            self.assertTrue(isdir(self.bb_result_lib_path))
-            self.assertTrue(isdir(self.bb_result_lib_path / "Elementalist"))
-            self.assertTrue(isdir(self.bb_result_lib_path / "fire_lib"))
-            self.assertTrue(isdir(self.bb_result_lib_path / "water_lib"))
-            self.assertTrue(
-                isdir(
-                    self.bb_result_lib_path / "Elementalist" / "external" /
-                    "fire_lib"
-                )
-            )
-            self.assertTrue(
-                isdir(
-                    self.bb_result_lib_path / "Elementalist" / "external" /
-                    "water_lib"
-                )
-            )
-
-    @mock.patch('benchbuild.source.base.target_prefix')
-    @mock.patch('varats.project.project_util.target_prefix')
-    def test_vara_test_repo_gitted_renaming(
-        self, mock_tgt_prefix_base, mock_tgt_prefix_project_util
-    ) -> None:
+    @run_in_test_environment(UnitTestFixtures.TEST_PROJECTS)
+    def test_vara_test_repo_gitted_renaming(self) -> None:
         """Test if the .gitted files are correctly renamed back to their
         original git name."""
+        self.elementalist.version(
+            f"{self.bb_result_report_path}/"
+            f"TwoLibsOneProjectInteractionDiscreteLibsSingleProject"
+            f"-cpp_projects@{self.revision}",
+            version=self.revision
+        )
 
-        with test_environment() as tmppath:
-            mock_tgt_prefix_base.return_value = \
-                tmppath / self.bb_tmp_path
-            mock_tgt_prefix_project_util.return_value = \
-                tmppath / self.bb_tmp_path
+        # Are .gitted files correctly renamed?
+        self.assertTrue(
+            isdir(self.bb_result_lib_path / "Elementalist" / ".git")
+        )
+        self.assertTrue(isdir(self.bb_result_lib_path / "fire_lib" / ".git"))
+        self.assertTrue(isdir(self.bb_result_lib_path / "water_lib" / ".git"))
+        self.assertTrue(
+            (self.bb_result_lib_path / "Elementalist" / ".gitmodules").exists()
+        )
 
-            self.elementalist.fetch()
-            self.elementalist.version(
-                self.bb_result_report_path / Path(
-                    f"TwoLibsOneProjectInteractionDiscreteLibsSingle"
-                    f"Project-cpp_projects@{self.revision}",
-                    version=self.revision
-                )
-            )
-
-            # Are .gitted files correctly renamed?
-            self.assertTrue(
-                isdir(self.bb_result_lib_path / "Elementalist" / ".git")
-            )
-            self.assertTrue(
-                isdir(self.bb_result_lib_path / "fire_lib" / ".git")
-            )
-            self.assertTrue(
-                isdir(self.bb_result_lib_path / "water_lib" / ".git")
-            )
-            self.assertTrue(
-                (self.bb_result_lib_path / "Elementalist" /
-                 ".gitmodules").exists()
-            )
-
-    @mock.patch('benchbuild.source.base.target_prefix')
-    @mock.patch('varats.project.project_util.target_prefix')
-    def test_vara_test_repo_lib_checkout(
-        self, mock_tgt_prefix_base, mock_tgt_prefix_project_util
-    ) -> None:
+    @run_in_test_environment(UnitTestFixtures.TEST_PROJECTS)
+    def test_vara_test_repo_lib_checkout(self) -> None:
         """Test if the repositories are checked out at the specified
         revision."""
+        self.elementalist.version(
+            f"{self.bb_result_report_path}/"
+            f"TwoLibsOneProjectInteractionDiscreteLibsSingleProject"
+            f"-cpp_projects@{self.revision}",
+            version=self.revision
+        )
 
-        with test_environment() as tmppath:
-            mock_tgt_prefix_base.return_value = \
-                tmppath / self.bb_tmp_path
-            mock_tgt_prefix_project_util.return_value = \
-                tmppath / self.bb_tmp_path
-
-            self.elementalist.fetch()
-            self.elementalist.version(
-                self.bb_result_report_path / Path(
-                    f"TwoLibsOneProjectInteractionDiscreteLibsSingle"
-                    f"Project-cpp_projects@{self.revision}",
-                    version=self.revision
-                )
+        # Are repositories checked out at correct commit hash?
+        with local.cwd(self.bb_result_lib_path / "Elementalist"):
+            self.assertEqual(
+                self.revision[:7],
+                git('rev-parse', '--short', 'HEAD').rstrip()
             )
 
-            # Are repositories checked out at correct commit hash?
-            with local.cwd(self.bb_result_lib_path / "Elementalist"):
-                self.assertEqual(
-                    "5e8fe16",
-                    git('rev-parse', '--short', 'HEAD').rstrip()
-                )
+        with local.cwd(self.bb_result_lib_path / "fire_lib"):
+            self.assertEqual(
+                "ead5e00",
+                git('rev-parse', '--short', 'HEAD').rstrip()
+            )
 
-            with local.cwd(self.bb_result_lib_path / "fire_lib"):
-                self.assertEqual(
-                    "ead5e00",
-                    git('rev-parse', '--short', 'HEAD').rstrip()
-                )
+        with local.cwd(self.bb_result_lib_path / "water_lib"):
+            self.assertEqual(
+                "58ec513",
+                git('rev-parse', '--short', 'HEAD').rstrip()
+            )
 
-            with local.cwd(self.bb_result_lib_path / "water_lib"):
-                self.assertEqual(
-                    "58ec513",
-                    git('rev-parse', '--short', 'HEAD').rstrip()
-                )
-
-            with local.cwd(self.bb_result_lib_path / "earth_lib"):
-                self.assertEqual(
-                    "1db6fbe",
-                    git('rev-parse', '--short', 'HEAD').rstrip()
-                )
+        with local.cwd(self.bb_result_lib_path / "earth_lib"):
+            self.assertEqual(
+                "1db6fbe",
+                git('rev-parse', '--short', 'HEAD').rstrip()
+            )
 
     def test_if_project_names_are_well_formed(self) -> None:
-        """Tests if project names are well formed, e.g., they must not contain a
+        """Tests if project names are well-formed, e.g., they must not contain a
         dash."""
 
         varats_cfg = create_new_varats_config()
@@ -273,7 +236,9 @@ class TestProjectBinaryWrapper(unittest.TestCase):
 
     def test_execution_of_executable(self) -> None:
         """Check if we can execute a executable bianries."""
-        binary = ProjectBinaryWrapper("ls", "/bin/ls", BinaryType.EXECUTABLE)
+        binary = ProjectBinaryWrapper(
+            "ls", Path("/bin/ls"), BinaryType.EXECUTABLE
+        )
 
         ret = binary()
         self.assertIsNotNone(ret)
@@ -282,11 +247,11 @@ class TestProjectBinaryWrapper(unittest.TestCase):
     def test_execution_of_libraries(self) -> None:
         """Check if we don't fail when executing a shared/static library."""
         static_lib_binary = ProjectBinaryWrapper(
-            "ls", "/bin/ls", BinaryType.STATIC_LIBRARY
+            "ls", Path("/bin/ls"), BinaryType.STATIC_LIBRARY
         )
         self.assertIsNone(static_lib_binary())
 
         shared_lib_binary = ProjectBinaryWrapper(
-            "ls", "/bin/ls", BinaryType.SHARED_LIBRARY
+            "ls", Path("/bin/ls"), BinaryType.SHARED_LIBRARY
         )
         self.assertIsNone(shared_lib_binary())

--- a/varats-core/varats/project/project_util.py
+++ b/varats-core/varats/project/project_util.py
@@ -9,10 +9,11 @@ from pathlib import Path
 import benchbuild as bb
 import pygit2
 from benchbuild.source import Git
-from benchbuild.source.base import target_prefix
 from benchbuild.utils.cmd import git
 from plumbum import local
 from plumbum.commands.base import BoundCommand
+
+from varats.utils.settings import bb_cfg
 
 LOG = logging.getLogger(__name__)
 
@@ -91,7 +92,13 @@ def get_local_project_git_path(
     if not is_git_source(source):
         raise AssertionError(f"Project {project_name} does not use git.")
 
-    return Path(source.fetch())
+    base = Path(str(bb_cfg()["tmp_dir"]))
+    git_path: Path = base / source.local
+    if not git_path.exists():
+        git_path = base / source.local.replace(os.sep, "-")
+    if not git_path.exists():
+        git_path = Path(source.fetch())
+    return git_path
 
 
 def get_extended_commit_lookup_source(

--- a/varats/varats/ts_utils/project_sources.py
+++ b/varats/varats/ts_utils/project_sources.py
@@ -22,7 +22,8 @@ class VaraTestRepoSubmodule(GitSubmodule):  # type: ignore
         remote="https://github.com/se-sic/vara-test-repos",
         local="vara_test_repos",
         refspec="origin/HEAD",
-        limit=1
+        shallow=False,
+        limit=None
     )
 
     def fetch(self) -> pb.LocalPath:
@@ -58,7 +59,8 @@ class VaraTestRepoSource(PaperConfigSpecificGit):
         remote="https://github.com/se-sic/vara-test-repos",
         local="vara_test_repos",
         refspec="origin/HEAD",
-        limit=1
+        shallow=False,
+        limit=None
     )
 
     def fetch(self) -> pb.LocalPath:


### PR DESCRIPTION
This is done by refactoring `get_local_project_git_path()` to only fetch a repo if it does not exist and providing a new test fixture that can provide isolated git repos (i.e., using our test environment decorator) that only clone from a local checkout.