### PR TITLE
Added option to bb config generation to include test_projects

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -92,7 +92,7 @@ class _TestEnvironment():
         settings._CFG = vara_cfg
         settings.save_config()
 
-        bb_cfg = create_new_bb_config(settings.vara_cfg())
+        bb_cfg = create_new_bb_config(settings.vara_cfg(), True)
         settings.save_bb_config(bb_cfg)
         # pylint: disable=protected-access
         settings._BB_CFG = bb_cfg

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -190,7 +190,6 @@ class TestEnvironment():
         settings._CFG = vara_cfg
         settings.save_config()
 
-
         bb_cfg = create_new_bb_config(settings.vara_cfg(), True)
         # make new bb_cfg point to old tmp to avoid multiple git clones
         bb_cfg["tmp_dir"] = str(self.__old_bb_config["tmp_dir"])

--- a/tests/utils/test_project_util.py
+++ b/tests/utils/test_project_util.py
@@ -253,7 +253,7 @@ class TestVaraTestRepoSource(unittest.TestCase):
         dash."""
 
         varats_cfg = create_new_varats_config()
-        bb_cfg = create_new_bb_config(varats_cfg)
+        bb_cfg = create_new_bb_config(varats_cfg, True)
         loaded_project_paths: tp.List[str] = bb_cfg["plugins"]["projects"].value
 
         loaded_project_names = [

--- a/varats/varats/tools/bb_config.py
+++ b/varats/varats/tools/bb_config.py
@@ -85,7 +85,7 @@ def create_new_bb_config(
         '.two_libs_one_project_interaction_discrete_libs_single_project'
     ]
     if include_test_projects:
-        projects_conf[:].value += [
+        projects_conf.value[:] += [
             'varats.projects.test_projects.basic_tests',
             'varats.projects.test_projects.bug_provider_test_repos',
             'varats.projects.test_projects.example_test_repos',

--- a/varats/varats/tools/bb_config.py
+++ b/varats/varats/tools/bb_config.py
@@ -15,7 +15,10 @@ from varats.tools.tool_util import (
 from varats.utils.settings import add_vara_experiment_options
 
 
-def create_new_bb_config(varats_cfg: s.Configuration) -> s.Configuration:
+def create_new_bb_config(
+    varats_cfg: s.Configuration,
+    include_test_projects: bool = False
+) -> s.Configuration:
     """
     Create a new default bb config.
 
@@ -24,6 +27,7 @@ def create_new_bb_config(varats_cfg: s.Configuration) -> s.Configuration:
 
     Args:
         varats_cfg: the varats config this bb config is based on
+        include_test_projects: changes whether test projects are included
 
     Returns:
         a new default bb config object
@@ -75,19 +79,21 @@ def create_new_bb_config(varats_cfg: s.Configuration) -> s.Configuration:
         'varats.projects.cpp_projects.libzmq',
         'varats.projects.cpp_projects.mongodb',
         'varats.projects.cpp_projects.poppler',
-        'varats.projects.test_projects.test_suite',
     ]
     projects_conf.value[:] += [
         'varats.projects.cpp_projects.doxygen', 'varats.projects.cpp_projects'
         '.two_libs_one_project_interaction_discrete_libs_single_project'
     ]
-    projects_conf.value[:] += ['varats.projects.test_projects.basic_tests']
-    projects_conf.value[:] += ['varats.projects.test_projects.linker_check']
-    projects_conf.value[:] += ['varats.projects.test_projects.taint_tests']
-
-    projects_conf.value[:] += [
-        'varats.projects.perf_tests.feature_perf_cs_collection'
-    ]
+    if include_test_projects:
+        projects_conf[:].value += [
+            'varats.projects.test_projects.basic_tests',
+            'varats.projects.test_projects.bug_provider_test_repos',
+            'varats.projects.test_projects.example_test_repos',
+            'varats.projects.test_projects.linker_check',
+            'varats.projects.test_projects.taint_tests',
+            'varats.projects.test_projects.test_suite',
+            'varats.projects.perf_tests.feature_perf_cs_collection'
+        ]
 
     # Experiments for VaRA
     projects_conf = new_bb_cfg["plugins"]["experiments"]

--- a/varats/varats/tools/driver_gen_benchbuild_config.py
+++ b/varats/varats/tools/driver_gen_benchbuild_config.py
@@ -20,7 +20,8 @@ LOG = logging.getLogger(__name__)
     type=click.Path(),
     help="Set an alternative BenchBuild root folder."
 )
-def main(bb_root: tp.Optional[str] = None) -> None:
+@click.option("--test-projects", is_flag=True, help="Include test projects")
+def main(bb_root: tp.Optional[str] = None, test_projects: bool = False) -> None:
     """
     Main function for the benchbuild config creator.
 
@@ -50,7 +51,7 @@ def main(bb_root: tp.Optional[str] = None) -> None:
         LOG.info(f"Setting BB path to: {vara_cfg()['benchbuild_root']}")
         save_config()
 
-    bb_cfg = create_new_bb_config(vara_cfg())
+    bb_cfg = create_new_bb_config(vara_cfg(), test_projects)
     save_bb_config(bb_cfg)
 
 


### PR DESCRIPTION
Added switch to only include test projects if explicitly requested with `--test-projects` switch.

Should we have this as an explicit parameter in the `create_new_bb_config`, or should we also put this in the `varats_cfg` that we pass?

resolves https://github.com/se-sic/VaRA/issues/851