### PR TITLE
Changed old se-passau github links to new se-sic

### DIFF
--- a/docs/source/research_tool_docs/vara/passes.rst
+++ b/docs/source/research_tool_docs/vara/passes.rst
@@ -1,7 +1,7 @@
 Passes
 ======
 
-`TODO (se-passau/VaRA#566) <https://github.com/se-passau/VaRA/issues/566>`_: write docs
+`TODO (se-sic/VaRA#566) <https://github.com/se-sic/VaRA/issues/566>`_: write docs
 
 .. toctree::
     :maxdepth: 1

--- a/docs/source/research_tool_docs/vara/setup.rst
+++ b/docs/source/research_tool_docs/vara/setup.rst
@@ -10,12 +10,12 @@ If you want to manually install llvm and VaRA see the following instructions.
 Linux
 .....
 To create your own setup or integrate VaRA into LLVM, follow these instructions.
-First, clone our modified version of `llvm's monorepo <https://github.com/se-passau/vara-llvm-project>`_ or patch our modifications into your version of llvm-project.
+First, clone our modified version of `llvm's monorepo <https://github.com/se-sic/vara-llvm-project>`_ or patch our modifications into your version of llvm-project.
 
 .. code-block:: bash
 
   cd where-you-want-llvm-to-live
-  git clone git@github.com:se-passau/vara-llvm-project.git vara-llvm-project
+  git clone git@github.com:se-sic/vara-llvm-project.git vara-llvm-project
   cd vara-llvm-project
   git submodule init && git submodule update --recursive
 
@@ -23,7 +23,7 @@ Second, checkout the VaRA repository as ``vara`` into ``vara-llvm-project``.
 
 .. code-block:: bash
 
-  git clone https://github.com/se-passau/VaRA.git vara
+  git clone https://github.com/se-sic/VaRA.git vara
   git submodule init && git submodule update --recursive
 
 Third, to complete the setup link the prepared VaRA build scripts into a build folder.

--- a/docs/source/research_tool_docs/vara/vara-api/analyses.rst
+++ b/docs/source/research_tool_docs/vara/vara-api/analyses.rst
@@ -3,9 +3,9 @@ Analysis passes
 
 Feature Analyses
 ----------------
-`TODO (se-passau/VaRA#566) <https://github.com/se-passau/VaRA/issues/566>`_: write docs
+`TODO (se-sic/VaRA#566) <https://github.com/se-sic/VaRA/issues/566>`_: write docs
 
 
 Commit Analyses
 ---------------
-`TODO (se-passau/VaRA#566) <https://github.com/se-passau/VaRA/issues/566>`_: write docs
+`TODO (se-sic/VaRA#566) <https://github.com/se-sic/VaRA/issues/566>`_: write docs

--- a/docs/source/vara-ts/slurm.rst
+++ b/docs/source/vara-ts/slurm.rst
@@ -115,7 +115,7 @@ Furthermore, this guide assumes that your vara-root directory is ``/scratch/<use
       # or
       sbatch --constraint=kine bb-configs/<report_type>-slurm-<project>.sh
 
-NOTE: If you want to run the same project again (with GenerateBlameReport), you need to empty the BC_files directory, because the path to the git repository will be different. See `#494 <https://github.com/se-passau/VaRA/issues/494>`_
+NOTE: If you want to run the same project again (with GenerateBlameReport), you need to empty the BC_files directory, because the path to the git repository will be different. See `#494 <https://github.com/se-sic/VaRA/issues/494>`_
 
 To use interaction filters, we recommend storing all of them in a separate directory (e.g., benchbuild/interaction_filters) with descriptive names and symlinking them to the place where the experiment expects them.
 

--- a/docs/source/vara-ts/vara-buildsetup.rst
+++ b/docs/source/vara-ts/vara-buildsetup.rst
@@ -48,7 +48,7 @@ First, you need to clone the VaRA-Tool-Suite repository.
 
 .. code-block:: console
 
-    git clone git@github.com:se-passau/VaRA-Tool-Suite.git
+    git clone git@github.com:se-sic/VaRA-Tool-Suite.git
     cd VaRA-Tool-Suite
 
 

--- a/tests/data/test_cve.py
+++ b/tests/data/test_cve.py
@@ -51,7 +51,7 @@ class TestSecurity(unittest.TestCase):
         self.assertTrue(cve.published == self.REFERENCE_CVE_DATA['published'])
         self.assertTrue(cve.vector == self.REFERENCE_CVE_DATA['vector'])
 
-    @unittest.skip("See se-passau/VaRA#646")
+    @unittest.skip("See se-sic/VaRA#646")
     def test_find_all_cve(self):
         """
         Get all OpenSSL CVE's and check if the Heartbleed CVE-2014-0160 is

--- a/varats-core/setup.py
+++ b/varats-core/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_namespace_packages, setup
 setup(
     name='varats-core',
     version='11.1.3',
-    url='https://github.com/se-passau/vara-tool-suite',
+    url='https://github.com/se-sic/vara-tool-suite',
     packages=find_namespace_packages(include=['varats.*']),
     namespace_packages=["varats"],
     setup_requires=["pytest-runner", "setuptools_scm"],

--- a/varats/setup.py
+++ b/varats/setup.py
@@ -11,7 +11,7 @@ with open(base_dir + '/README.md') as f:
 setup(
     name='varats',
     version='11.1.3',
-    url='https://github.com/se-passau/vara-tool-suite',
+    url='https://github.com/se-sic/vara-tool-suite',
     packages=find_namespace_packages(include=['varats.*']),
     namespace_packages=["varats"],
     setup_requires=["pytest-runner", "setuptools_scm"],

--- a/varats/varats/data/reports/blame_report.py
+++ b/varats/varats/data/reports/blame_report.py
@@ -497,7 +497,7 @@ def count_interacting_authors(
         interaction: BlameInstInteractions
     ) -> tp.Iterable[str]:
         return map_commits(
-            # Issue (se-passau/VaRA#647): improve author uniquifying
+            # Issue (se-sic/VaRA#647): improve author uniquifying
             lambda c: tp.cast(str, c.author.name),
             interaction.interacting_commits,
             commit_lookup
@@ -661,7 +661,7 @@ def generate_author_degree_tuples(
     for func_entry in report.function_entries:
         for interaction in func_entry.interactions:
             author_list = map_commits(
-                # Issue (se-passau/VaRA#647): improve author uniquifying
+                # Issue (se-sic/VaRA#647): improve author uniquifying
                 lambda c: tp.cast(str, c.author.name),
                 interaction.interacting_commits,
                 commit_lookup

--- a/varats/varats/projects/c_projects/gzip.py
+++ b/varats/varats/projects/c_projects/gzip.py
@@ -43,7 +43,7 @@ class Gzip(VProject, ReleaseProviderHook):
 
     SOURCE = [
         block_revisions([
-            # TODO (se-passau/VaRA#537): glibc < 2.28
+            # TODO (se-sic/VaRA#537): glibc < 2.28
             # see e.g. https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=915151
             RevisionRange(
                 "6ef28aeb035af20818578b1a1bc537f797c27029",

--- a/varats/varats/projects/cpp_projects/doxygen.py
+++ b/varats/varats/projects/cpp_projects/doxygen.py
@@ -30,7 +30,7 @@ class Doxygen(VProject):
 
     SOURCE = [
         block_revisions([
-            # TODO: se-passau/VaRA#536
+            # TODO: se-sic/VaRA#536
             GoodBadSubgraph(["a6238a4898e20422fe6ef03fce4891c5749b1553"],
                             ["cf936efb8ae99dd297b6afb9c6a06beb81f5b0fb"],
                             "Needs flex <= 2.5.4 and >= 2.5.33"),

--- a/varats/varats/tools/research_tools/vara.py
+++ b/varats/varats/tools/research_tools/vara.py
@@ -56,7 +56,7 @@ class VaRACodeBase(CodeBase):
                 "vara-llvm-project"
             ),
             SubProject(
-                self, "VaRA", "git@github.com:se-passau/VaRA.git", "origin",
+                self, "VaRA", "git@github.com:se-sic/VaRA.git", "origin",
                 "vara-llvm-project/vara"
             ),
             SubProject(
@@ -74,7 +74,7 @@ class VaRACodeBase(CodeBase):
         """Sets up VaRA specific upstream remotes for projects that were
         forked."""
         self.get_sub_project("vara-llvm-project").add_remote(
-            "origin", "git@github.com:se-passau/vara-llvm-project.git"
+            "origin", "git@github.com:se-sic/vara-llvm-project.git"
         )
 
     def setup_build_link(self) -> None:
@@ -143,7 +143,7 @@ class VaRA(ResearchTool[VaRACodeBase]):
     """
     Research tool implementation for VaRA.
 
-    Find the main repo online on github: https://github.com/se-passau/VaRA
+    Find the main repo online on github: https://github.com/se-sic/VaRA
     """
 
     __DEPENDENCIES = Dependencies({


### PR DESCRIPTION
There are still several github links using the `se-passau` org instead of `se-sic`.

While these old ones still work git will always complain when using them, so we should probably update those.