### PR TITLE
Set  mounting parameters according to the Buildah version when building Containers

### DIFF
--- a/docs/source/tutorials/getting_started.rst
+++ b/docs/source/tutorials/getting_started.rst
@@ -10,14 +10,14 @@ For ubuntu:
 
 .. code-block:: console
 
-    sudo apt install python3-dev python3-tk python3-psutil psutils ninja-build python3-pip autoconf cmake ruby curl time libyaml-dev git
+    sudo apt install python3-dev python3-tk python3-psutil psutils ninja-build python3-pip autoconf cmake ruby curl time libyaml-dev git graphviz-dev
     sudo apt install python3-venv # If you want to install VaRA-TS in a python virtualenv
 
 For arch:
 
 .. code-block:: console
 
-    sudo pacman -Syu --needed python tk python-psutil psutils ninja python-pip python-statsmodels autoconf cmake ruby curl time libyaml python-coverage
+    sudo pacman -Syu --needed python tk python-psutil psutils ninja python-pip python-statsmodels autoconf cmake ruby curl time libyaml python-coverage graphviz
 
 We recommend to use a virtual environment to install VaRA-TS.
 

--- a/docs/source/vara-ts/vara-buildsetup.rst
+++ b/docs/source/vara-ts/vara-buildsetup.rst
@@ -16,20 +16,20 @@ For ubuntu:
 
 .. code-block:: console
 
-    sudo apt install python3-dev python3-tk python3-psutil psutils ninja-build python3-pip autoconf cmake ruby curl time libyaml-dev git
+    sudo apt install python3-dev python3-tk python3-psutil psutils ninja-build python3-pip autoconf cmake ruby curl time libyaml-dev git graphviz-dev
     sudo apt install python3-venv # If you want to install VaRA-TS in a python virtualenv
 
 For arch:
 
 .. code-block:: console
 
-    sudo pacman -Syu --needed python tk python-psutil psutils ninja python-pip python-statsmodels autoconf cmake ruby curl time libyaml python-coverage
+    sudo pacman -Syu --needed python tk python-psutil psutils ninja python-pip python-statsmodels autoconf cmake ruby curl time libyaml python-coverage graphviz
 
 For fedora:
 
 .. code-block:: console
 
-    sudo dnf install python3-devel python3-tkinter python3-psutil psutils ninja-build python3-pip autoconf cmake ruby curl time libyaml-devel gcc-c++ libgit2-devel gcc-gfortran openblas-devel
+    sudo dnf install python3-devel python3-tkinter python3-psutil psutils ninja-build python3-pip autoconf cmake ruby curl time libyaml-devel gcc-c++ libgit2-devel gcc-gfortran openblas-devel graphviz-devel
 
 Install to varats with pip
 **************************

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -5,6 +5,7 @@ import unittest.mock as mock
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
+from benchbuild.environments.adapters.common import buildah_version
 from benchbuild.environments.domain.model import (
     Layer,
     FromLayer,
@@ -120,7 +121,10 @@ class TestContainerSupport(unittest.TestCase):
             "install", "--ignore-installed", "/varats/varats-core",
             "/varats/varats"
         ), varats_install_layer.args)
-        self.assertIn(("mount", "type=bind,src=varats_src,target=/varats,rw"),
+        mounting_parameters = "type=bind,src=varats_src,target=/varats"
+        if buildah_version() >= (1, 24, 0):
+            mounting_parameters += ",rm"
+        self.assertIn(("mount", mounting_parameters),
                       varats_install_layer.kwargs)
 
     @run_in_test_environment()

--- a/varats-core/setup.py
+++ b/varats-core/setup.py
@@ -10,7 +10,7 @@ setup(
     setup_requires=["pytest-runner", "setuptools_scm"],
     tests_require=["pytest", "pytest-cov"],
     install_requires=[
-        "benchbuild>=6.3.0",
+        "benchbuild>=6.3.1",
         "plumbum>=1.6.6",
         "PyGithub>=1.47",
         "PyDriller>=2.0",

--- a/varats/setup.py
+++ b/varats/setup.py
@@ -18,7 +18,7 @@ setup(
     tests_require=["pytest", "pytest-cov"],
     install_requires=[
         "argparse-utils>=1.2.0",
-        "benchbuild>=6.3.0",
+        "benchbuild>=6.3.1",
         "click>=8.0.1",
         "distro>=1.5.0",
         "graphviz>=0.14.2",

--- a/varats/varats/containers/containers.py
+++ b/varats/varats/containers/containers.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 
 from benchbuild.environments import bootstrap
+from benchbuild.environments.adapters.common import buildah_version
 from benchbuild.environments.domain.commands import (
     CreateImage,
     fs_compliant_name,
@@ -217,12 +218,14 @@ def _add_varats_layers(image_context: BaseImageCreationContext) -> None:
         if editable_install:
             pip_args.append("-e")
             _set_varats_source_mount(image_context, str(src_dir))
-
+        mount = f'type=bind,src={src_dir},target={tgt_dir}'
+        if buildah_version() >= (1, 24, 0):
+            mount += ',rw'
         image.run(
             *pip_args,
             str(tgt_dir / 'varats-core'),
             str(tgt_dir / 'varats'),
-            mount=f'type=bind,src={src_dir},target={tgt_dir},rw',
+            mount=mount,
             runtime=crun
         )
 

--- a/varats/varats/containers/containers.py
+++ b/varats/varats/containers/containers.py
@@ -61,7 +61,7 @@ _BASE_IMAGES: tp.Dict[ImageBase, tp.Callable[[], ContainerImage]] = {
             'apt', 'install', '-y', 'wget', 'gnupg', 'lsb-release',
             'software-properties-common', 'python3', 'python3-dev',
             'python3-pip', 'musl-dev', 'git', 'gcc', 'libgit2-dev',
-            'libffi-dev', 'libyaml-dev'
+            'libffi-dev', 'libyaml-dev', 'graphviz-dev'
         ).run('wget', 'https://apt.llvm.org/llvm.sh').
         run('chmod', '+x', './llvm.sh').run('./llvm.sh', '13', 'all').run(
             'ln', '-s', '/usr/bin/clang-13', '/usr/bin/clang'


### PR DESCRIPTION
Set the `rw` mounting parameter when the installed buildah version requires it and not if it does not. Also update the required benchbuild version to 3.6.1. to include this fix in benchbuild as well. 
