### PR TITLE
Make older Revisions of x264 build

### DIFF
--- a/varats/varats/projects/c_projects/x264.py
+++ b/varats/varats/projects/c_projects/x264.py
@@ -3,11 +3,7 @@ import typing as tp
 
 import benchbuild as bb
 from benchbuild.utils.cmd import make
-from benchbuild.utils.revision_ranges import (
-    block_revisions,
-    GoodBadSubgraph,
-    RevisionRange,
-)
+from benchbuild.utils.revision_ranges import block_revisions, GoodBadSubgraph
 from benchbuild.utils.settings import get_number_of_jobs
 from plumbum import local
 

--- a/varats/varats/projects/c_projects/x264.py
+++ b/varats/varats/projects/c_projects/x264.py
@@ -3,6 +3,11 @@ import typing as tp
 
 import benchbuild as bb
 from benchbuild.utils.cmd import make
+from benchbuild.utils.revision_ranges import (
+    block_revisions,
+    GoodBadSubgraph,
+    RevisionRange,
+)
 from benchbuild.utils.settings import get_number_of_jobs
 from plumbum import local
 
@@ -31,13 +36,19 @@ class X264(VProject):
     DOMAIN = ProjectDomains.CODEC
 
     SOURCE = [
-        PaperConfigSpecificGit(
-            project_name="x264",
-            remote="https://code.videolan.org/videolan/x264.git",
-            local="x264",
-            refspec="origin/HEAD",
-            limit=None,
-            shallow=False
+        block_revisions([
+            GoodBadSubgraph(["5dc0aae2f900064d1f58579929a2285ab289a436"],
+                            ["6490f4398d9e28e65d7517849e729e14eede8c5b"],
+                            "Does not build on x64 out of the box")
+        ])(
+            PaperConfigSpecificGit(
+                project_name="x264",
+                remote="https://code.videolan.org/videolan/x264.git",
+                local="x264",
+                refspec="origin/HEAD",
+                limit=None,
+                shallow=False
+            )
         )
     ]
 
@@ -56,23 +67,30 @@ class X264(VProject):
 
     def compile(self) -> None:
         """Compile the project."""
-        x264_git_path = get_local_project_git_path(self.NAME)
         x264_version_source = local.path(self.source_of_primary)
-        x264_version = self.version_of_primary
+        x264_version = ShortCommitHash(self.version_of_primary)
 
-        with local.cwd(x264_git_path):
-            old_revisions = get_all_revisions_between(
-                "5dc0aae2f900064d1f58579929a2285ab289a436",
-                "290de9638e5364c37316010ac648a6c959f6dd26", ShortCommitHash
-            )
+        fpic_revisions = get_all_revisions_between(
+            "5dc0aae2f900064d1f58579929a2285ab289a436",
+            "290de9638e5364c37316010ac648a6c959f6dd26", ShortCommitHash,
+            x264_version_source
+        )
+        ldflags_revisions = get_all_revisions_between(
+            "6490f4398d9e28e65d7517849e729e14eede8c5b",
+            "275ef5332dffec445a0c5a78dbc00c3e0766011d", ShortCommitHash,
+            x264_version_source
+        )
 
-        if x264_version in old_revisions:
+        if x264_version in fpic_revisions:
             self.cflags += ["-fPIC"]
 
         clang = bb.compiler.cc(self)
         with local.cwd(x264_version_source):
             with local.env(CC=str(clang)):
-                bb.watch(local["./configure"])("--disable-asm")
+                configure_flags = ["--disable-asm"]
+                if x264_version in ldflags_revisions:
+                    configure_flags.append("--extra-ldflags=\"-static\"")
+                bb.watch(local["./configure"])(configure_flags)
             bb.watch(make)("-j", get_number_of_jobs(bb_cfg()))
 
             verify_binaries(self)


### PR DESCRIPTION
make the compile function of x264 build older revisions and block very old revisions that do not build. 
resolves se-sic/VaRA#478
resolves se-sic/VaRA#479 