### PR TITLE
Make libssh compile again

### DIFF
--- a/varats/varats/projects/c_projects/libssh.py
+++ b/varats/varats/projects/c_projects/libssh.py
@@ -86,15 +86,12 @@ class Libssh(VProject):
 
     def compile(self) -> None:
         """Compile the project."""
-        libssh_git_path = get_local_project_git_path(self.NAME)
-        libssh_version = self.version_of_primary
-
-        with local.cwd(libssh_git_path):
-            cmake_revisions = get_all_revisions_between(
-                "0151b6e17041c56813c882a3de6330c82acc8d93", "master",
-                ShortCommitHash
-            )
-
+        libssh_source = local.path(self.source_of(self.primary_source))
+        libssh_version = ShortCommitHash(self.version_of_primary)
+        cmake_revisions = get_all_revisions_between(
+            "0151b6e17041c56813c882a3de6330c82acc8d93", "master",
+            ShortCommitHash, libssh_source
+        )
         if libssh_version in cmake_revisions:
             self.__compile_cmake()
         else:
@@ -116,14 +113,16 @@ class Libssh(VProject):
 
     def __compile_make(self) -> None:
         libssh_source = local.path(self.source_of(self.primary_source))
-        libssh_version = self.version_of_primary
+        libssh_version = ShortCommitHash(self.version_of_primary)
         autoconf_revisions = get_all_revisions_between(
             "5e02c25291d594e01a910fce097a3fc5084fd68f",
-            "21e639cc3fd54eb3d59568744c9627beb26e07ed", ShortCommitHash
+            "21e639cc3fd54eb3d59568744c9627beb26e07ed", ShortCommitHash,
+            libssh_source
         )
         autogen_revisions = get_all_revisions_between(
             "ca32b0aa146b31d7772f27d16098845e615432aa",
-            "ee54acb417c5589a8dc9dab0676f34b3d40a182b", ShortCommitHash
+            "ee54acb417c5589a8dc9dab0676f34b3d40a182b", ShortCommitHash,
+            libssh_source
         )
         compiler = bb.compiler.cc(self)
         with local.cwd(libssh_source):


### PR DESCRIPTION
Fix an issue in the compile function in libssh.py which prevented it from building.