### PR TITLE
Bump Click version requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 argparse-utils>=1.2.0
 benchbuild>=6.3.0
-click>=8.0.1
+click>=8.0.2
 distro>=1.5.0
 graphviz>=0.14.2
 Jinja2>=3.0.1

--- a/varats/setup.py
+++ b/varats/setup.py
@@ -19,7 +19,7 @@ setup(
     install_requires=[
         "argparse-utils>=1.2.0",
         "benchbuild>=6.3.1",
-        "click>=8.0.1",
+        "click>=8.0.2",
         "Cryptography<37.0.0",
         "distro>=1.5.0",
         "graphviz>=0.14.2",


### PR DESCRIPTION
Click version 8.0.1 contains a bug which breaks our `TypedMultiChoice` this is fixed in version 8.0.2

resolves se-sic/VaRA#913