### PR TITLE
Removes old cryptography dep as the cycle is removed

### DIFF
--- a/varats-core/setup.py
+++ b/varats-core/setup.py
@@ -13,7 +13,6 @@ setup(
         "benchbuild>=6.4.0",
         "plumbum>=1.6.6",
         "PyGithub>=1.47",
-        "Cryptography<37.0.0",
         "PyDriller>=2.0",
         "requests>=2.23.0",
         "packaging>=20.1",

--- a/varats/setup.py
+++ b/varats/setup.py
@@ -20,7 +20,6 @@ setup(
         "argparse-utils>=1.2.0",
         "benchbuild>=6.4.0",
         "click>=8.0.2",
-        "Cryptography<37.0.0",
         "distro>=1.5.0",
         "graphviz>=0.14.2",
         "Jinja2>=3.0.1",


### PR DESCRIPTION
The old import cycle that was fixed by this dependency seems now to be resolved. Furthermore, the old cryptography version is no longer available on some systems.