### PR TITLE
Extract artefact functionality from paper config.

### DIFF
--- a/tests/paper/test_artefacts.py
+++ b/tests/paper/test_artefacts.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from tempfile import NamedTemporaryFile
 
 from tests.test_utils import run_in_test_environment, UnitTestFixtures
-from varats.data.reports.empty_report import EmptyReport
 from varats.experiments.base.just_compile import JustCompileReport
 from varats.paper_mgmt.artefacts import (
     initialize_artefact_types,

--- a/tests/tools/test_driver_artefacts.py
+++ b/tests/tools/test_driver_artefacts.py
@@ -5,7 +5,7 @@ from click.testing import CliRunner
 
 from tests.test_utils import run_in_test_environment, UnitTestFixtures
 from varats.data.discover_reports import initialize_reports
-from varats.paper_mgmt.artefacts import Artefact
+from varats.paper_mgmt.artefacts import Artefact, load_artefacts
 from varats.paper_mgmt.paper_config import get_paper_config, load_paper_config
 from varats.plots.discover_plots import initialize_plots
 from varats.tables.discover_tables import initialize_tables
@@ -31,7 +31,7 @@ class TestDriverArtefacts(unittest.TestCase):
         # setup config
         vara_cfg()['paper_config']['current_config'] = "test_artefacts_driver"
         load_paper_config()
-        artefacts = get_paper_config().get_all_artefacts()
+        artefacts = load_artefacts(get_paper_config()).artefacts
         base_output_dir = Artefact.base_output_dir()
 
         # vara-art generate

--- a/tests/tools/test_driver_plot.py
+++ b/tests/tools/test_driver_plot.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from click.testing import CliRunner
 
 from tests.test_utils import run_in_test_environment, UnitTestFixtures
+from varats.paper_mgmt.artefacts import load_artefacts
 from varats.paper_mgmt.paper_config import get_paper_config, load_paper_config
 from varats.plot.plots import PlotArtefact
 from varats.tools import driver_plot
@@ -63,7 +64,7 @@ class TestDriverPlot(unittest.TestCase):
 
         # load new artefact file
         load_paper_config()
-        artefacts = list(get_paper_config().artefacts)
+        artefacts = list(load_artefacts(get_paper_config()).artefacts)
         self.assertEqual(1, len(artefacts))
 
         artefact = artefacts[0]

--- a/varats-core/setup.py
+++ b/varats-core/setup.py
@@ -10,7 +10,7 @@ setup(
     setup_requires=["pytest-runner", "setuptools_scm"],
     tests_require=["pytest", "pytest-cov"],
     install_requires=[
-        "benchbuild>=6.4.0",
+        "benchbuild>=6.4.0,<6.5.0",
         "plumbum>=1.6.6",
         "PyGithub>=1.47",
         "PyDriller>=2.0",

--- a/varats/setup.py
+++ b/varats/setup.py
@@ -18,7 +18,7 @@ setup(
     tests_require=["pytest", "pytest-cov"],
     install_requires=[
         "argparse-utils>=1.2.0",
-        "benchbuild>=6.4.0",
+        "benchbuild>=6.4.0,<6.5.0",
         "click>=8.0.2",
         "distro>=1.5.0",
         "graphviz>=0.14.2",

--- a/varats/varats/paper_mgmt/artefacts.py
+++ b/varats/varats/paper_mgmt/artefacts.py
@@ -12,6 +12,7 @@ import abc
 import logging
 import typing as tp
 from abc import ABC
+from functools import cache
 from pathlib import Path
 
 from varats.base.version_header import VersionHeader
@@ -22,6 +23,7 @@ if tp.TYPE_CHECKING:
     from rich.progress import Progress  # pylint: disable=unused-import
 
     import varats.paper.case_study as cs  # pylint: disable=unused-import
+    import varats.paper_mgmt.paper_config as pc  # pylint: disable=unused-import
 
 LOG = logging.getLogger(__name__)
 
@@ -148,12 +150,17 @@ class Artefact(ABC):
         """
 
 
-class Artefacts:
-    r"""
-    A collection of :class:`Artefact`\ s.
-    """
+_ARTEFACTS_FILE_NAME = 'artefacts.yaml'
+_ARTEFACTS_FILE_VERSION = 2
 
-    def __init__(self, artefacts: tp.Iterable[Artefact]) -> None:
+
+class Artefacts:
+    r"""A collection of :class:`Artefact`\ s."""
+
+    def __init__(
+        self, file_path: Path, artefacts: tp.Iterable[Artefact]
+    ) -> None:
+        self.__file_path = file_path
         self.__artefacts = {artefact.name: artefact for artefact in artefacts}
 
     @property
@@ -186,6 +193,16 @@ class Artefacts:
         """
         self.__artefacts[artefact.name] = artefact
 
+    def store(self) -> None:
+        """Store artefacts in their artefacts file."""
+        store_as_yaml(
+            self.__file_path, [
+                VersionHeader.from_version_number(
+                    'Artefacts', _ARTEFACTS_FILE_VERSION
+                ), self
+            ]
+        )
+
     def __iter__(self) -> tp.Iterator[Artefact]:
         return self.__artefacts.values().__iter__()
 
@@ -198,7 +215,21 @@ class Artefacts:
         )
 
 
-__ARTEFACTS_FILE_VERSION = 2
+@cache
+def load_artefacts(paper_config: 'pc.PaperConfig') -> Artefacts:
+    """
+    Load the artefacts for a paper config.
+
+    Args:
+        paper_config: the paper config to load the artefacts for
+
+    Returns:
+        the artefacts object for the given paper config
+    """
+    file_path = paper_config.path / _ARTEFACTS_FILE_NAME
+    if file_path.exists():
+        return load_artefacts_from_file(file_path)
+    return Artefacts(file_path, [])
 
 
 def load_artefacts_from_file(file_path: Path) -> Artefacts:
@@ -214,7 +245,7 @@ def load_artefacts_from_file(file_path: Path) -> Artefacts:
     documents = load_yaml(file_path)
     version_header = VersionHeader(next(documents))
     version_header.raise_if_not_type("Artefacts")
-    version_header.raise_if_version_is_less_than(__ARTEFACTS_FILE_VERSION)
+    version_header.raise_if_version_is_less_than(_ARTEFACTS_FILE_VERSION)
 
     raw_artefacts = next(documents)
     artefacts: tp.List[Artefact] = []
@@ -242,24 +273,7 @@ def load_artefacts_from_file(file_path: Path) -> Artefacts:
             artefact_type.create_artefact(name, output_dir, **raw_artefact)
         )
 
-    return Artefacts(artefacts)
-
-
-def store_artefacts_to_file(artefacts: Artefacts, file_path: Path) -> None:
-    """
-    Store artefacts in a file.
-
-    Args:
-        artefacts: the artefacts to store
-        file_path: the file to store in
-    """
-    store_as_yaml(
-        file_path, [
-            VersionHeader.from_version_number(
-                'Artefacts', __ARTEFACTS_FILE_VERSION
-            ), artefacts
-        ]
-    )
+    return Artefacts(file_path, artefacts)
 
 
 def initialize_artefact_types() -> None:

--- a/varats/varats/paper_mgmt/artefacts.py
+++ b/varats/varats/paper_mgmt/artefacts.py
@@ -12,7 +12,7 @@ import abc
 import logging
 import typing as tp
 from abc import ABC
-from functools import cache
+from functools import lru_cache
 from pathlib import Path
 
 from varats.base.version_header import VersionHeader
@@ -215,7 +215,7 @@ class Artefacts:
         )
 
 
-@cache
+@lru_cache(maxsize=1)
 def load_artefacts(paper_config: 'pc.PaperConfig') -> Artefacts:
     """
     Load the artefacts for a paper config.

--- a/varats/varats/paper_mgmt/paper_config.py
+++ b/varats/varats/paper_mgmt/paper_config.py
@@ -18,12 +18,6 @@ from varats.paper.case_study import (
     load_case_study_from_file,
     store_case_study,
 )
-from varats.paper_mgmt.artefacts import (
-    Artefact,
-    Artefacts,
-    load_artefacts_from_file,
-    store_artefacts_to_file,
-)
 from varats.utils.exceptions import ConfigurationLookupError
 from varats.utils.git_util import ShortCommitHash
 from varats.utils.settings import vara_cfg
@@ -54,25 +48,11 @@ class PaperConfig():
                 self.__case_studies[case_study.project_name].append(case_study)
             else:
                 self.__case_studies[case_study.project_name] = [case_study]
-        self.__artefacts: tp.Optional[Artefacts] = None
 
     @property
     def path(self) -> Path:
         """Path to the paper config folder."""
         return self.__path
-
-    @property
-    def artefacts(self) -> Artefacts:
-        """The artefacts of this paper config."""
-        if not self.__artefacts:
-            if (self.path / self.__ARTEFACTS_FILE_NAME).exists():
-                self.__artefacts = load_artefacts_from_file(
-                    self.path / self.__ARTEFACTS_FILE_NAME
-                )
-            else:
-                self.__artefacts = Artefacts([])
-
-        return self.__artefacts
 
     def get_case_studies(self, cs_name: str) -> tp.List[CaseStudy]:
         """
@@ -97,10 +77,6 @@ class PaperConfig():
             case_study for case_study_list in self.__case_studies.values()
             for case_study in case_study_list
         ]
-
-    def get_all_artefacts(self) -> tp.Iterable[Artefact]:
-        """Returns an iterable of the artefacts of this paper config."""
-        return self.artefacts
 
     def has_case_study(self, cs_name: str) -> bool:
         """
@@ -154,29 +130,12 @@ class PaperConfig():
         """
         self.__case_studies[case_study.project_name] += [case_study]
 
-    def add_artefact(self, artefact: Artefact) -> None:
-        """
-        Add a new artefact to this paper config.
-
-        Args:
-            artefact: the artefact to add
-        """
-        self.artefacts.add_artefact(artefact)
-
-    def store_artefacts(self) -> None:
-        """Store artefacts to file."""
-        if self.artefacts:
-            store_artefacts_to_file(
-                self.artefacts, self.path / self.__ARTEFACTS_FILE_NAME
-            )
-
     def store(self) -> None:
         """Persist the current state of the paper config saving all case studies
         to their corresponding files in the paper config path."""
         for case_study_list in self.__case_studies.values():
             for case_study in case_study_list:
                 store_case_study(case_study, self.__path)
-        self.store_artefacts()
 
     def __str__(self) -> str:
         string = "Loaded case studies:\n"

--- a/varats/varats/tools/driver_artefacts.py
+++ b/varats/varats/tools/driver_artefacts.py
@@ -15,7 +15,11 @@ import yaml
 from rich.progress import Progress
 
 from varats.data.discover_reports import initialize_reports
-from varats.paper_mgmt.artefacts import Artefact, initialize_artefact_types
+from varats.paper_mgmt.artefacts import (
+    Artefact,
+    initialize_artefact_types,
+    load_artefacts,
+)
 from varats.paper_mgmt.paper_config import get_paper_config
 from varats.plot.plots import PlotArtefact
 from varats.plots.discover_plots import initialize_plots
@@ -58,7 +62,7 @@ def list_() -> None:
     """List the available artefacts."""
     paper_config = get_paper_config()
 
-    for artefact in paper_config.artefacts:
+    for artefact in load_artefacts(paper_config):
         print(f"{artefact.name} [{artefact.ARTEFACT_TYPE}]")
 
 
@@ -72,7 +76,7 @@ def show(name: str) -> None:
         name: the name of the artefact
     """
     paper_config = get_paper_config()
-    artefact = paper_config.artefacts.get_artefact(name)
+    artefact = load_artefacts(paper_config).get_artefact(name)
     if artefact:
         print(f"Artefact '{name}':")
         print(textwrap.indent(yaml.dump(artefact.get_dict()), '  '))
@@ -103,11 +107,11 @@ def generate(only: tp.Optional[str]) -> None:
 
     if only:
         artefacts = [
-            art for art in get_paper_config().get_all_artefacts()
+            art for art in load_artefacts(get_paper_config())
             if art.name in only
         ]
     else:
-        artefacts = get_paper_config().get_all_artefacts()
+        artefacts = load_artefacts(get_paper_config())
 
     with Progress() as progress:
         for artefact in progress.track(

--- a/varats/varats/tools/driver_plot.py
+++ b/varats/varats/tools/driver_plot.py
@@ -12,6 +12,7 @@ import typing as tp
 import click
 from rich.progress import Progress
 
+from varats.paper_mgmt.artefacts import load_artefacts
 from varats.paper_mgmt.paper_config import get_paper_config
 from varats.plot.plots import (
     PlotGenerator,
@@ -54,7 +55,8 @@ class PlotCLI(click.MultiCommand):
                 generator_instance = generator_cls(plot_config, **kwargs)
                 if artefact_name:
                     paper_config = get_paper_config()
-                    if paper_config.artefacts.get_artefact(artefact_name):
+                    artefacts = load_artefacts(paper_config)
+                    if artefacts.get_artefact(artefact_name):
                         LOG.info(
                             f"Updating existing artefact '{artefact_name}'."
                         )
@@ -63,8 +65,8 @@ class PlotCLI(click.MultiCommand):
                     artefact = PlotArtefact.from_generator(
                         artefact_name, generator_instance, common_options
                     )
-                    paper_config.add_artefact(artefact)
-                    paper_config.store_artefacts()
+                    artefacts.add_artefact(artefact)
+                    artefacts.store()
                 else:
                     with Progress() as progress:
                         generator_instance(common_options, progress)

--- a/varats/varats/tools/driver_table.py
+++ b/varats/varats/tools/driver_table.py
@@ -12,6 +12,7 @@ import typing as tp
 import click
 from rich.progress import Progress
 
+from varats.paper_mgmt.artefacts import load_artefacts
 from varats.paper_mgmt.paper_config import get_paper_config
 from varats.plots.discover_plots import initialize_plots
 from varats.projects.discover_projects import initialize_projects
@@ -54,7 +55,8 @@ class TableCLI(click.MultiCommand):
                 generator_instance = generator_cls(table_config, **kwargs)
                 if artefact_name:
                     paper_config = get_paper_config()
-                    if paper_config.artefacts.get_artefact(artefact_name):
+                    artefacts = load_artefacts(paper_config)
+                    if artefacts.get_artefact(artefact_name):
                         LOG.info(
                             f"Updating existing artefact '{artefact_name}'."
                         )
@@ -63,8 +65,8 @@ class TableCLI(click.MultiCommand):
                     artefact = TableArtefact.from_generator(
                         artefact_name, generator_instance, common_options
                     )
-                    paper_config.add_artefact(artefact)
-                    paper_config.store_artefacts()
+                    artefacts.add_artefact(artefact)
+                    artefacts.store()
                 else:
                     with Progress() as progress:
                         generator_instance(common_options, progress)


### PR DESCRIPTION
This separates artefacts from the paper config and allows us to later migrate the paper config to varats-core.