### PR TITLE
Changed project name from "fast_downward" to "FastDownward"

### DIFF
--- a/tests/utils/test_project_util.py
+++ b/tests/utils/test_project_util.py
@@ -276,8 +276,8 @@ class TestTaggedCommits(unittest.TestCase):
     def test_get_tagged_commits_lightweight(self) -> None:
         """Check if we can get list of tagged commits from a project when
         lightweight tags are used."""
-        fast_downward_tagged_commits = set(get_tagged_commits("fast_downward"))
-        fast_downward_repo_loc = get_local_project_git_path("fast_downward")
+        fast_downward_tagged_commits = set(get_tagged_commits("FastDownward"))
+        fast_downward_repo_loc = get_local_project_git_path("FastDownward")
         with local.cwd(fast_downward_repo_loc):
             for (hash_value, _) in fast_downward_tagged_commits:
                 self.assertTrue(self.hash_belongs_to_commit(hash_value))

--- a/varats/varats/projects/cpp_projects/fast_downward.py
+++ b/varats/varats/projects/cpp_projects/fast_downward.py
@@ -1,4 +1,4 @@
-"""Project file for fast_downward."""
+"""Project file for FastDownward."""
 import re
 import typing as tp
 
@@ -32,15 +32,15 @@ from varats.utils.settings import bb_cfg
 class FastDownward(VProject, ReleaseProviderHook):
     """Planning tool FastDownward (fetched by Git)"""
 
-    NAME = 'fast_downward'
+    NAME = 'FastDownward'
     GROUP = 'cpp_projects'
     DOMAIN = ProjectDomains.PLANNING
 
     SOURCE = [
         PaperConfigSpecificGit(
-            project_name="fast_downward",
+            project_name="FastDownward",
             remote="https://github.com/aibasel/downward.git",
-            local="fast_downward",
+            local="FastDownward",
             refspec="origin/HEAD",
             limit=None,
             shallow=False


### PR DESCRIPTION
I changed the project name from "fast_downward" to "FastDownward" to make it consistent with the naming the ConfigurableSystems repository (otherwise, the feature model is not found)