### PR TITLE
Remove packaging.LegacyVersion usage

### DIFF
--- a/varats-core/varats/provider/cve/cve.py
+++ b/varats-core/varats/provider/cve/cve.py
@@ -15,7 +15,7 @@ import zipfile
 from datetime import datetime
 
 import requests
-from packaging.version import LegacyVersion, Version
+from packaging.version import Version
 from packaging.version import parse as version_parse
 from tabulate import tabulate
 
@@ -31,7 +31,7 @@ class CVE:
     def __init__(
         self, cve_id: str, score: float, published: datetime,
         vector: tp.FrozenSet[str], references: tp.FrozenSet[str], summary: str,
-        vulnerable_versions: tp.FrozenSet[tp.Union[LegacyVersion, Version]]
+        vulnerable_versions: tp.FrozenSet[Version]
     ) -> None:
         self.__cve_id = cve_id
         self.__score = score
@@ -72,9 +72,7 @@ class CVE:
         return self.__summary
 
     @property
-    def vulnerable_versions(
-        self
-    ) -> tp.FrozenSet[tp.Union[LegacyVersion, Version]]:
+    def vulnerable_versions(self) -> tp.FrozenSet[Version]:
         """The set of vulnerable version numbers."""
         return self.__vulnerable_versions
 

--- a/varats-core/varats/provider/cve/cve_map.py
+++ b/varats-core/varats/provider/cve/cve_map.py
@@ -33,7 +33,7 @@ from collections import defaultdict
 from pathlib import Path
 
 from benchbuild.utils.cmd import git
-from packaging.version import LegacyVersion, Version
+from packaging.version import Version
 from packaging.version import parse as parse_version
 from plumbum import local
 
@@ -164,8 +164,7 @@ def __collect_via_version(
     results: CVEDict = defaultdict(__create_cve_dict_entry)
 
     # Collect tagged commits
-    tag_list: tp.Dict[tp.Union[LegacyVersion, Version], tp.Dict[str,
-                                                                tp.Any]] = {}
+    tag_list: tp.Dict[Version, tp.Dict[str, tp.Any]] = {}
     for number, commit_data in enumerate(reversed(commits)):
         commit, message = commit_data
         tag = re.findall(r'\(tag:\s*.*\)', message, re.IGNORECASE)


### PR DESCRIPTION
I created a new Python virtualenvironment today and encountered the following error while running `vara-cs cleanup`:
```
ImportError: cannot import name 'LegacyVersion' from 'packaging.version'
```
Turns out that our dependency `packaging` got a new release and removed the already deprecated `LegacyVersion`.
https://github.com/pypa/packaging/blob/main/CHANGELOG.rst#220---2022-12-07

Fixed this by removing our usage of `LegacyVersion`.