### PR TITLE
fix plot_file_name when using REQUIRE_MULTI_CASE_STUDY

### DIFF
--- a/varats/varats/plot/plot.py
+++ b/varats/varats/plot/plot.py
@@ -149,8 +149,17 @@ class Plot:
         """
         plot_ident = ''
         if 'case_study' in self.plot_kwargs:
-            case_study: 'CaseStudy' = self.plot_kwargs['case_study']
-            plot_ident = f"{case_study.project_name}_{case_study.version}_"
+            if isinstance(self.plot_kwargs['case_study'], list):
+                case_studies: tp.List[CaseStudy] = self.plot_kwargs['case_study'
+                                                                   ]
+                plot_ident += "-".join([
+                    f"{case_study.project_name}_{case_study.version}"
+                    for case_study in case_studies
+                ])
+                plot_ident += "_"
+            else:
+                case_study: CaseStudy = self.plot_kwargs['case_study']
+                plot_ident = f"{case_study.project_name}_{case_study.version}_"
         elif 'project' in self.plot_kwargs:
             plot_ident = f"{self.plot_kwargs['project']}_"
 


### PR DESCRIPTION
When using [REQUIRE_MULTI_CASE_STUDY](https://github.com/se-sic/VaRA-Tool-Suite/blob/3b9c93f911ca9de0ca6eaf94292ad4cdc0911e79/varats/varats/ts_utils/click_param_types.py#L201) as PlotGenerator option `self.plot_kwargs['case_study']` will be a list.
The current `plot_file_name` function doesn't expect that and fails in [line 153](https://github.com/se-sic/VaRA-Tool-Suite/blob/333aba8756221250cbe3bee208776c208c46bc23/varats/varats/plot/plot.py#L153) with
```
│   150 │   │   plot_ident = ''                                                                                        │
│   151 │   │   if 'case_study' in self.plot_kwargs:                                                                   │
│   152 │   │   │   case_study: 'CaseStudy' = self.plot_kwargs['case_study']                                           │
│ ❱ 153 │   │   │   plot_ident = f"{case_study.project_name}_{case_study.version}_"                                    │
│   154 │   │   elif 'project' in self.plot_kwargs:                                                                    │
│   155 │   │   │   plot_ident = f"{self.plot_kwargs['project']}_"                                                     │
│   156                                                                                                                │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
AttributeError: 'list' object has no attribute 'project_name'
```
Fix this by treating the list case different.