### PR TITLE
Introduces unlimited stack wrapper for phasar using experiments

### DIFF
--- a/varats-core/varats/experiment/experiment_util.py
+++ b/varats-core/varats/experiment/experiment_util.py
@@ -26,6 +26,7 @@ from benchbuild.source import enumerate_revisions
 from benchbuild.utils.actions import Step, MultiStep, StepResult, run_any_child
 from benchbuild.utils.cmd import prlimit, mkdir
 from plumbum.commands import ProcessExecutionError
+from plumbum.commands.base import BoundCommand
 
 import varats.revision.revisions as revs
 from varats.base.configuration import (
@@ -282,13 +283,15 @@ def wrap_unlimit_stack_size(cmd: tp.Callable[..., tp.Any]) -> tp.Any:
     return prlimit[f"--stack={max_stacksize_16gb}:", cmd]
 
 
-class WithUnlimitedStackSize(base.Extension):
+class WithUnlimitedStackSize(base.Extension):  # type: ignore
     """Sets the stack size of the wrapped command to unlimited (16GB)."""
 
-    def __init__(self, *extensions, **kwargs):
+    def __init__(self, *extensions, **kwargs) -> None:
         super().__init__(*extensions, **kwargs)
 
-    def __call__(self, binary_command, *args, **kwargs):
+    def __call__(
+        self, binary_command: BoundCommand, *args: tp.Any, **kwargs: tp.Any
+    ) -> tp.Any:
         return self.call_next(
             wrap_unlimit_stack_size(binary_command), *args, **kwargs
         )

--- a/varats-core/varats/experiment/experiment_util.py
+++ b/varats-core/varats/experiment/experiment_util.py
@@ -286,7 +286,7 @@ def wrap_unlimit_stack_size(cmd: tp.Callable[..., tp.Any]) -> tp.Any:
 class WithUnlimitedStackSize(base.Extension):  # type: ignore
     """Sets the stack size of the wrapped command to unlimited (16GB)."""
 
-    def __init__(self, *extensions, **kwargs) -> None:
+    def __init__(self, *extensions: tp.Any, **kwargs: tp.Any) -> None:
         super().__init__(*extensions, **kwargs)
 
     def __call__(

--- a/varats-core/varats/experiment/experiment_util.py
+++ b/varats-core/varats/experiment/experiment_util.py
@@ -20,6 +20,7 @@ else:
 
 from benchbuild import source
 from benchbuild.experiment import Experiment
+from benchbuild.extensions import base
 from benchbuild.project import Project
 from benchbuild.source import enumerate_revisions
 from benchbuild.utils.actions import Step, MultiStep, StepResult, run_any_child
@@ -279,6 +280,18 @@ def wrap_unlimit_stack_size(cmd: tp.Callable[..., tp.Any]) -> tp.Any:
     """
     max_stacksize_16gb = 17179869184
     return prlimit[f"--stack={max_stacksize_16gb}:", cmd]
+
+
+class WithUnlimitedStackSize(base.Extension):
+    """Sets the stack size of the wrapped command to unlimited (16GB)."""
+
+    def __init__(self, *extensions, **kwargs):
+        super().__init__(*extensions, **kwargs)
+
+    def __call__(self, binary_command, *args, **kwargs):
+        return self.call_next(
+            wrap_unlimit_stack_size(binary_command), *args, **kwargs
+        )
 
 
 VersionType = tp.TypeVar('VersionType')

--- a/varats/varats/experiments/vara/feature_perf_runner.py
+++ b/varats/varats/experiments/vara/feature_perf_runner.py
@@ -5,7 +5,10 @@ import typing as tp
 from benchbuild.extensions import compiler, run, time
 from benchbuild.utils import actions
 
-from varats.experiment.experiment_util import get_default_compile_error_wrapped
+from varats.experiment.experiment_util import (
+    get_default_compile_error_wrapped,
+    WithUnlimitedStackSize,
+)
 from varats.experiments.vara.feature_experiment import (
     FeatureExperiment,
     RunVaRATracedWorkloads,
@@ -47,6 +50,7 @@ class FeaturePerfRunner(FeatureExperiment, shorthand="FPR"):
 
         # Add the required compiler extensions to the project(s).
         project.compiler_extension = compiler.RunCompiler(project, self) \
+            << WithUnlimitedStackSize() \
             << run.WithTimeout()
 
         # Add own error handler to compile step.
@@ -90,6 +94,7 @@ class FeaturePerfXRayRunner(FeatureExperiment, shorthand="FXR"):
             << time.RunWithTime()
 
         project.compiler_extension = compiler.RunCompiler(project, self) \
+            << WithUnlimitedStackSize() \
             << run.WithTimeout()
 
         project.compile = get_default_compile_error_wrapped(

--- a/varats/varats/experiments/vara/instrumentation_verifier.py
+++ b/varats/varats/experiments/vara/instrumentation_verifier.py
@@ -8,7 +8,10 @@ from benchbuild.utils import actions
 from varats.data.reports.instrumentation_verifier_report import (
     InstrVerifierReport,
 )
-from varats.experiment.experiment_util import get_default_compile_error_wrapped
+from varats.experiment.experiment_util import (
+    get_default_compile_error_wrapped,
+    WithUnlimitedStackSize,
+)
 from varats.experiments.vara.feature_experiment import (
     FeatureExperiment,
     RunVaRATracedWorkloads,
@@ -52,7 +55,8 @@ class RunInstrVerifier(FeatureExperiment, shorthand="RIV"):
         project.runtime_extension = run.RuntimeExtension(project, self)
 
         # Add the required compiler extensions to the project(s).
-        project.compiler_extension = compiler.RunCompiler(project, self)
+        project.compiler_extension = compiler.RunCompiler(project, self) \
+            << WithUnlimitedStackSize()
 
         # Add own error handler to compile step.
         project.compile = get_default_compile_error_wrapped(


### PR DESCRIPTION
Phasar uses a high amount of stack space due to its recursive solver implementation. So, to not run out of stack space during phasar analyses that are part of clang/lld, we introduce a prlimit wrapper that sets the stackspace to the maximal size.