### PR TITLE
Fix string to case study conversion for artifact files

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -195,6 +195,7 @@ good-names=a,
            df,
            id,
            pc,
+           cs
 
 # Include a hint for the correct naming format with invalid-name.
 include-naming-hint=no

--- a/tests/TEST_INPUTS/paper_configs/test_artefacts_driver/artefacts.yaml
+++ b/tests/TEST_INPUTS/paper_configs/test_artefacts_driver/artefacts.yaml
@@ -41,13 +41,10 @@ artefacts:
   artefact_type_version: 2
   case_study: all
   dry_run: false
-  experiment_type: JustCompile
   file_type: svg
-  name: "CS Overview (all)"
+  name: "Repo Churn (all)"
   output_dir: .
   plot_config: {}
-  plot_generator: cs-overview-plot
-  show_all_blocked: false
-  show_blocked: true
+  plot_generator: repo-churn-plot
   view: false
 ...

--- a/tests/TEST_INPUTS/paper_configs/test_artefacts_driver/artefacts.yaml
+++ b/tests/TEST_INPUTS/paper_configs/test_artefacts_driver/artefacts.yaml
@@ -1,5 +1,7 @@
+---
 DocType: Artefacts
 Version: 2
+...
 ---
 artefacts:
 - artefact_type: plot
@@ -22,3 +24,30 @@ artefacts:
   table_generator: diff-correlation-overview-table
   view: false
   wrap_table: false
+- artefact_type: plot
+  artefact_type_version: 2
+  case_study: xz_0
+  dry_run: false
+  experiment_type: JustCompile
+  file_type: svg
+  name: "CS Overview (xz)"
+  output_dir: .
+  plot_config: {}
+  plot_generator: cs-overview-plot
+  show_all_blocked: false
+  show_blocked: true
+  view: false
+- artefact_type: plot
+  artefact_type_version: 2
+  case_study: all
+  dry_run: false
+  experiment_type: JustCompile
+  file_type: svg
+  name: "CS Overview (all)"
+  output_dir: .
+  plot_config: {}
+  plot_generator: cs-overview-plot
+  show_all_blocked: false
+  show_blocked: true
+  view: false
+...

--- a/tests/paper/test_artefacts.py
+++ b/tests/paper/test_artefacts.py
@@ -190,9 +190,9 @@ class TestArtefacts(unittest.TestCase):
         self.assertEqual("xz", cs_xz.project_name)
         self.assertEqual(0, cs_xz.version)
 
-        cs_overview_all = artefacts.get_artefact("CS Overview (all)")
-        self.assertIsNotNone(cs_overview_all)
-        self.assertIsInstance(cs_overview_all, PlotArtefact)
-        cs_all = cs_overview_all.plot_kwargs["case_study"]
+        churn_all = artefacts.get_artefact("Repo Churn (all)")
+        self.assertIsNotNone(churn_all)
+        self.assertIsInstance(churn_all, PlotArtefact)
+        cs_all = churn_all.plot_kwargs["case_study"]
         self.assertIsInstance(cs_all, tp.List)
         self.assertEqual(2, len(cs_all))

--- a/tests/tools/test_driver_artefacts.py
+++ b/tests/tools/test_driver_artefacts.py
@@ -1,4 +1,5 @@
 """Test artefacts config tool."""
+import traceback
 import unittest
 
 from click.testing import CliRunner
@@ -64,8 +65,8 @@ class TestDriverArtefacts(unittest.TestCase):
         result = runner.invoke(driver_artefacts.main, ["list"])
         self.assertEqual(0, result.exit_code, result.exception)
         self.assertEqual(
-            "Paper Config Overview [plot]\nCorrelation Table [table]\n",
-            result.stdout
+            "Paper Config Overview [plot]\nCorrelation Table [table]\n"
+            "CS Overview (xz) [plot]\nRepo Churn (all) [plot]\n", result.stdout
         )
 
     @run_in_test_environment(UnitTestFixtures.PAPER_CONFIGS)

--- a/varats/varats/paper_mgmt/artefacts.py
+++ b/varats/varats/paper_mgmt/artefacts.py
@@ -206,6 +206,9 @@ class Artefacts:
     def __iter__(self) -> tp.Iterator[Artefact]:
         return self.__artefacts.values().__iter__()
 
+    def __len__(self) -> int:
+        return len(self.__artefacts)
+
     def get_dict(
         self
     ) -> tp.Dict[str, tp.List[tp.Dict[str, tp.Union[str, int]]]]:

--- a/varats/varats/ts_utils/artefact_util.py
+++ b/varats/varats/ts_utils/artefact_util.py
@@ -5,7 +5,7 @@ from benchbuild.experiment import ExperimentRegistry
 
 from varats.experiment.experiment_util import VersionExperiment
 from varats.paper.case_study import CaseStudy
-from varats.paper.paper_config import get_loaded_paper_config
+from varats.paper.paper_config import get_loaded_paper_config, PaperConfig
 from varats.report.report import BaseReport
 from varats.ts_utils.cli_util import (
     CLIOptionConverter,
@@ -34,13 +34,18 @@ class CaseStudyConverter(CLIOptionConverter[CaseStudy]):
     ) -> tp.Union[CaseStudy, tp.List[CaseStudy]]:
         pc = get_loaded_paper_config()
         if isinstance(str_value, tp.List):
-            return [
-                cs for cs_name in str_value
-                for cs in pc.get_case_studies(cs_name)
-            ]
+            return [_str_to_cs(cs_str, pc) for cs_str in str_value]
         if str_value == "all":
             return pc.get_all_case_studies()
-        return pc.get_case_studies(str_value)[0]
+        return _str_to_cs(str_value, pc)
+
+
+def _str_to_cs(str_value: str, pc: PaperConfig) -> CaseStudy:
+    cs_name, cs_version = str_value.rsplit("_", 1)
+    for cs in pc.get_case_studies(cs_name):
+        if cs.version == int(cs_version):
+            return cs
+    raise AssertionError("Case study not found.")
 
 
 class ReportTypeConverter(CLIOptionConverter[tp.Type[BaseReport]]):


### PR DESCRIPTION
Case study arguments stored in artifact files weren't properly converted back to case studies when loading the artifact file.