### PR TITLE
Make LoadRepositoryForTest importable from varats

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,7 +8,6 @@ import typing as tp
 from functools import wraps
 from pathlib import Path
 from threading import Lock
-from types import TracebackType
 
 import benchbuild.source.base as base
 import benchbuild.utils.settings as bb_settings
@@ -19,13 +18,8 @@ from benchbuild.utils.cmd import git
 
 import varats.utils.settings as settings
 from varats.base.configuration import ConfigurationImpl, ConfigurationOptionImpl
-from varats.project.project_util import (
-    is_git_source,
-    get_local_project_git_path,
-)
+from varats.project.project_util import is_git_source
 from varats.tools.bb_config import create_new_bb_config
-from varats.utils.git_commands import checkout_branch_or_commit
-from varats.utils.git_util import ShortCommitHash, get_head_commit
 
 if sys.version_info <= (3, 8):
     from typing_extensions import Protocol
@@ -289,23 +283,3 @@ class ConfigurationHelper:
         )
         test_config.add_config_option(ConfigurationOptionImpl("buzz", "None"))
         return test_config
-
-
-class LoadRepositoryForTest():
-    """Context manager to work with a repository at a specific revision, without
-    duplicating the repository."""
-
-    def __init__(self, project_name: str, revision: ShortCommitHash) -> None:
-        self.__repo_path = get_local_project_git_path(project_name)
-        self.__revision = revision
-        self.__initial_head = get_head_commit(self.__repo_path)
-
-    def __enter__(self) -> None:
-        checkout_branch_or_commit(self.__repo_path, self.__revision)
-
-    def __exit__(
-        self, exc_type: tp.Optional[tp.Type[BaseException]],
-        exc_value: tp.Optional[BaseException],
-        exc_traceback: tp.Optional[TracebackType]
-    ) -> None:
-        checkout_branch_or_commit(self.__repo_path, self.__initial_head)

--- a/tests/utils/test_git_util.py
+++ b/tests/utils/test_git_util.py
@@ -4,13 +4,13 @@ from pathlib import Path
 
 from benchbuild.utils.revision_ranges import RevisionRange
 
-from tests.test_utils import LoadRepositoryForTest
 from varats.project.project_util import (
     get_local_project_git,
     get_local_project_git_path,
     BinaryType,
 )
 from varats.projects.discover_projects import initialize_projects
+from varats.utils.git_commands import LoadRepository
 from varats.utils.git_util import (
     ChurnConfig,
     CommitRepoPair,
@@ -124,7 +124,7 @@ class TestGitInteractionHelpers(unittest.TestCase):
         """Check if correct submodule commit is retrieved."""
         repo_head = FullCommitHash("cb15dfa4b2d7fba0d50e87b49f979c7f996b8ebc")
 
-        with LoadRepositoryForTest("grep", repo_head.to_short_commit_hash()):
+        with LoadRepository("grep", repo_head.to_short_commit_hash()):
             submodule_head = get_submodule_head("grep", "gnulib", repo_head)
             self.assertEqual(
                 submodule_head,
@@ -135,7 +135,7 @@ class TestGitInteractionHelpers(unittest.TestCase):
         """Check if correct main repo commit is retrieved."""
         repo_head = FullCommitHash("cb15dfa4b2d7fba0d50e87b49f979c7f996b8ebc")
 
-        with LoadRepositoryForTest("grep", repo_head.to_short_commit_hash()):
+        with LoadRepository("grep", repo_head.to_short_commit_hash()):
             submodule_head = get_submodule_head("grep", "grep", repo_head)
             self.assertEqual(submodule_head, repo_head)
 

--- a/tests/utils/test_git_util.py
+++ b/tests/utils/test_git_util.py
@@ -10,7 +10,6 @@ from varats.project.project_util import (
     BinaryType,
 )
 from varats.projects.discover_projects import initialize_projects
-from varats.utils.git_commands import LoadRepository
 from varats.utils.git_util import (
     ChurnConfig,
     CommitRepoPair,
@@ -28,6 +27,7 @@ from varats.utils.git_util import (
     RevisionBinaryMap,
     get_submodule_head,
     calc_code_churn_range,
+    RepositoryAtCommit,
 )
 
 
@@ -124,7 +124,7 @@ class TestGitInteractionHelpers(unittest.TestCase):
         """Check if correct submodule commit is retrieved."""
         repo_head = FullCommitHash("cb15dfa4b2d7fba0d50e87b49f979c7f996b8ebc")
 
-        with LoadRepository("grep", repo_head.to_short_commit_hash()):
+        with RepositoryAtCommit("grep", repo_head.to_short_commit_hash()):
             submodule_head = get_submodule_head("grep", "gnulib", repo_head)
             self.assertEqual(
                 submodule_head,
@@ -135,7 +135,7 @@ class TestGitInteractionHelpers(unittest.TestCase):
         """Check if correct main repo commit is retrieved."""
         repo_head = FullCommitHash("cb15dfa4b2d7fba0d50e87b49f979c7f996b8ebc")
 
-        with LoadRepository("grep", repo_head.to_short_commit_hash()):
+        with RepositoryAtCommit("grep", repo_head.to_short_commit_hash()):
             submodule_head = get_submodule_head("grep", "grep", repo_head)
             self.assertEqual(submodule_head, repo_head)
 

--- a/varats-core/varats/utils/git_commands.py
+++ b/varats-core/varats/utils/git_commands.py
@@ -5,13 +5,7 @@ from types import TracebackType
 
 from benchbuild.utils.cmd import git
 
-from varats.project.project_util import get_local_project_git_path
-from varats.utils.git_util import (
-    get_current_branch,
-    CommitHash,
-    ShortCommitHash,
-    get_head_commit,
-)
+from varats.utils.git_util import get_current_branch, CommitHash
 
 
 def add_remote(repo_folder: Path, remote: str, url: str) -> None:
@@ -154,24 +148,3 @@ def download_repo(
     output = git("-C", dl_folder, args)
     for line in output.split("\n"):
         post_out(line)
-
-
-class LoadRepository():
-    """Context manager to work with a repository at a specific revision, without
-    duplicating the repository."""
-
-    def __init__(self, project_name: str, revision: ShortCommitHash) -> None:
-        self.__repo_path = get_local_project_git_path(project_name)
-        self.__revision = revision
-        self.__initial_head = get_head_commit(self.__repo_path)
-
-    def __enter__(self) -> Path:
-        checkout_branch_or_commit(self.__repo_path, self.__revision)
-        return self.__repo_path
-
-    def __exit__(
-        self, exc_type: tp.Optional[tp.Type[BaseException]],
-        exc_value: tp.Optional[BaseException],
-        exc_traceback: tp.Optional[TracebackType]
-    ) -> None:
-        checkout_branch_or_commit(self.__repo_path, self.__initial_head)

--- a/varats-core/varats/utils/git_commands.py
+++ b/varats-core/varats/utils/git_commands.py
@@ -1,7 +1,6 @@
 """This module contains wrapper for basic git commands."""
 import typing as tp
 from pathlib import Path
-from types import TracebackType
 
 from benchbuild.utils.cmd import git
 

--- a/varats-core/varats/utils/git_util.py
+++ b/varats-core/varats/utils/git_util.py
@@ -1121,7 +1121,7 @@ class RepositoryAtCommit():
 
     def __enter__(self) -> Path:
         self.__repo.checkout_tree(self.__revision)
-        return self.__repo.path
+        return Path(self.__repo.path)
 
     def __exit__(
         self, exc_type: tp.Optional[tp.Type[BaseException]],

--- a/varats-core/varats/utils/git_util.py
+++ b/varats-core/varats/utils/git_util.py
@@ -6,6 +6,7 @@ import typing as tp
 from enum import Enum
 from itertools import chain
 from pathlib import Path
+from types import TracebackType
 
 import pygit2
 from benchbuild.utils.cmd import git, grep
@@ -1105,3 +1106,26 @@ def branch_has_upstream(
             branch_name + "@{upstream}"] | grep[upstream]
     ) & RETCODE
     return tp.cast(bool, exit_code == 0)
+
+
+class RepositoryAtCommit():
+    """Context manager to work with a repository at a specific revision, without
+    duplicating the repository."""
+
+    def __init__(self, project_name: str, revision: ShortCommitHash) -> None:
+        self.__repo = pygit2.Repository(
+            get_local_project_git_path(project_name)
+        )
+        self.__initial_head = self.__repo.head
+        self.__revision = self.__repo.get(revision.hash)
+
+    def __enter__(self) -> Path:
+        self.__repo.checkout_tree(self.__revision)
+        return self.__repo.path
+
+    def __exit__(
+        self, exc_type: tp.Optional[tp.Type[BaseException]],
+        exc_value: tp.Optional[BaseException],
+        exc_traceback: tp.Optional[TracebackType]
+    ) -> None:
+        self.__repo.checkout(self.__initial_head)


### PR DESCRIPTION
My [CoveragePlot](https://github.com/se-sic/VaRA-Tool-Suite/blob/2275f635df6dc0360809ffddf36fafe91374963a/varats/varats/plots/llvm_coverage_plot.py#L296) needs to checkout the state of the git repo used during the experiment, since it has to read the src files. LoadRepositoryForTest provides the needed functionality. However, it cannot be imported easyily.
Move it to the varats utils to solve this and return the `repo_path` in the `__enter__` method to avoid calling `get_local_project_git_path` in later code.