### PR TITLE
Return path to repo in RepositoryAtCommit

### DIFF
--- a/varats-core/varats/utils/git_util.py
+++ b/varats-core/varats/utils/git_util.py
@@ -1121,7 +1121,7 @@ class RepositoryAtCommit():
 
     def __enter__(self) -> Path:
         self.__repo.checkout_tree(self.__revision)
-        return Path(self.__repo.path)
+        return Path(self.__repo.path).parent
 
     def __exit__(
         self, exc_type: tp.Optional[tp.Type[BaseException]],


### PR DESCRIPTION
`pygit2.Repository.path` points to the `.git` folder in a repo. However, we are more interested in the path to the repo itself. Fix this by returning the parent folder.