### PR TITLE
Add missing labels to workloads in FeaturePerfCSCollection

### DIFF
--- a/varats/varats/projects/perf_tests/feature_perf_cs_collection.py
+++ b/varats/varats/projects/perf_tests/feature_perf_cs_collection.py
@@ -56,14 +56,21 @@ class FeaturePerfCSCollection(VProject):
             ),
             Command(
                 SourceRoot("FeaturePerfCSCollection") /
-                RSBinary("SimpleFeatureInteraction"), "--enc", "--compress"
+                RSBinary("SimpleFeatureInteraction"),
+                "--enc",
+                "--compress",
+                label="SFI-enc-compress"
             )
         ],
         WorkloadSet(WorkloadCategory.MEDIUM): [
             Command(
                 SourceRoot("FeaturePerfCSCollection") /
-                RSBinary("SimpleBusyLoop"), "--iterations", str(10**7),
-                "--count_to", str(5 * 10**3)
+                RSBinary("SimpleBusyLoop"),
+                "--iterations",
+                str(10**7),
+                "--count_to",
+                str(5 * 10**3),
+                label="SBL-iterations-count-to"
             )
         ]
     }

--- a/varats/varats/projects/perf_tests/feature_perf_cs_collection.py
+++ b/varats/varats/projects/perf_tests/feature_perf_cs_collection.py
@@ -70,7 +70,7 @@ class FeaturePerfCSCollection(VProject):
                 str(10**7),
                 "--count_to",
                 str(5 * 10**3),
-                label="SBL-iterations-count-to"
+                label="SBL-iterations-10M-count-to-5K"
             )
         ]
     }


### PR DESCRIPTION
https://github.com/se-sic/VaRA-Tool-Suite/pull/748 added new workloads without labels for FeaturePerfCSCollection. However, `create_workload_specific_filename` expects labels https://github.com/se-sic/VaRA-Tool-Suite/blob/06c2d3466a862039f5e08361e1899a15750a1593/varats-core/varats/experiment/workload_util.py#L106 and fails if `cmd.label` is `None`.
It might be a good idea to add a check for missing labels when creating a workload. But for now just define some labels.