### PR TITLE
Use pandas.concat instead of DataFrame.append

### DIFF
--- a/varats-core/varats/utils/github_util.py
+++ b/varats-core/varats/utils/github_util.py
@@ -109,11 +109,14 @@ def _cache_pygithub_object(key: str, obj: GithubObject) -> None:
         obj: the object to store
     """
     cache_df = _load_cache_file()
-    cache_df = cache_df.append({
-        __PYGITHUB_KEY_COLUMN: key,
-        __PYGITHUB_OBJECT_COLUMN: _dump_pygithub_object(obj)
-    },
-                               ignore_index=True)
+    cache_df = pd.concat((
+        cache_df,
+        pd.DataFrame({
+            __PYGITHUB_KEY_COLUMN: [key],
+            __PYGITHUB_OBJECT_COLUMN: [_dump_pygithub_object(obj)]
+        })
+    ),
+                         ignore_index=True)
     _store_cache_file(cache_df)
 
 


### PR DESCRIPTION
Pandas 2.0 removes the deprecated `DataFrame.append`. Replace our usage with `pandas.concat` as suggested in their [changelog](https://pandas.pydata.org/docs/dev/whatsnew/v2.0.0.html) to fix our [build failure](https://github.com/se-sic/VaRA-Tool-Suite/actions/runs/4616873781/jobs/8162436590).