### PR TITLE
Cleanup: remove parent dir when no file left instead of returning StopIteration

### DIFF
--- a/varats/varats/tools/driver_casestudy.py
+++ b/varats/varats/tools/driver_casestudy.py
@@ -735,9 +735,7 @@ def __delete_report_file_paths(report_files: tp.List[ReportFilepath]) -> None:
     for file in report_files:
         file.full_path().unlink(missing_ok=True)
         parent_dir = file.full_path().parent
-        if parent_dir != file.base_path and next(
-            parent_dir.iterdir(), None
-        ) is None:
+        if parent_dir != file.base_path and not any(parent_dir.iterdir()):
             parent_dir.rmdir()
 
 

--- a/varats/varats/tools/driver_casestudy.py
+++ b/varats/varats/tools/driver_casestudy.py
@@ -735,7 +735,9 @@ def __delete_report_file_paths(report_files: tp.List[ReportFilepath]) -> None:
     for file in report_files:
         file.full_path().unlink(missing_ok=True)
         parent_dir = file.full_path().parent
-        if parent_dir != file.base_path and next(parent_dir.iterdir()) is None:
+        if parent_dir != file.base_path and next(
+            parent_dir.iterdir(), None
+        ) is None:
             parent_dir.rmdir()
 
 


### PR DESCRIPTION
Running `vara-cs cleanup -exp GenerateCoverage all` to remove my result files yields the following StopIteration exception, because we remove all files in a directory and then attempt to get the first one in there.
```
│ VaRA-Tool-Suite/varats/varats/tools/driver_casestudy.py:738 in                           │
│ __delete_report_file_paths                                                                                           │
│                                                                                                                      │
│   735 │   for file in report_files:                                                                                  │
│   736 │   │   file.full_path().unlink(missing_ok=True)                                                               │
│   737 │   │   parent_dir = file.full_path().parent                                                                   │
│ ❱ 738 │   │   if parent_dir != file.base_path and next(parent_dir.iterdir()) is None:                                │
│   739 │   │   │   parent_dir.rmdir()                                                                                 │
│   740                                                                                                                │
│   741                                                                                                                │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
StopIteration
```
Fix this by adding a default to next().