### PR TITLE
Hashable Configurations

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ click>=8.1.3
 distro>=1.5.0
 graphviz>=0.14.2
 ijson>=3.1.4
+immutables>=0.19
 Jinja2>=3.1.2
 jupyter>=1.0.0
 kaleido>=0.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ click>=8.1.3
 distro>=1.5.0
 graphviz>=0.14.2
 ijson>=3.1.4
-immutables>=0.19
 Jinja2>=3.1.2
 jupyter>=1.0.0
 kaleido>=0.2.1

--- a/tests/base/test_configuration.py
+++ b/tests/base/test_configuration.py
@@ -99,6 +99,7 @@ class TestConfiguration(unittest.TestCase):
         """Test to compare configuration to a mapping."""
         config = ConfigurationImpl()
         config.add_config_option(ConfigurationOptionImpl("foo", 42))
+
         mapping_identical = {"foo": 42}
         mapping_not_identical = {"foo": 43}
         mapping_interpreted = {"foo": True}
@@ -115,6 +116,15 @@ class TestConfiguration(unittest.TestCase):
 
         self.assertFalse(config == mapping_not_interpreted)
         self.assertTrue(config != mapping_not_interpreted)
+
+        config_2 = ConfigurationImpl()
+        config_2.add_config_option(ConfigurationOptionImpl("foo", False))
+
+        self.assertFalse(config_2 == mapping_interpreted)
+        self.assertTrue(config_2 != mapping_interpreted)
+
+        self.assertTrue(config_2 == mapping_not_interpreted)
+        self.assertFalse(config_2 != mapping_not_interpreted)
 
     def test_equality_othertypes(self) -> None:
         """Test to compare configuration to each other."""

--- a/tests/mapping/test_configuration_map.py
+++ b/tests/mapping/test_configuration_map.py
@@ -92,8 +92,8 @@ class TestConfigurationMap(unittest.TestCase):
         config_map.add_configuration(test_config_3)
 
         self.assertEqual(3, len(config_map.configurations()))
-        self.assertSetEqual({test_config_1, test_config_2, test_config_3},
-                            set(config_map.configurations()))
+        self.assertEqual([test_config_1, test_config_2, test_config_3],
+                         list(config_map.configurations()))
 
     def test_inter_id_config_tuples(self) -> None:
         """Test if we can iterate over all id configuration pairs."""
@@ -107,9 +107,9 @@ class TestConfigurationMap(unittest.TestCase):
         config_map.add_configuration(test_config_3)
 
         self.assertEqual(3, len(config_map.id_config_tuples()))
-        self.assertSetEqual({(0, test_config_1), (1, test_config_2),
-                             (2, test_config_3)},
-                            set(config_map.id_config_tuples()))
+        self.assertEqual([(0, test_config_1), (1, test_config_2),
+                          (2, test_config_3)],
+                         list(config_map.id_config_tuples()))
 
 
 class TestConfigurationMapStoreAndLoad(unittest.TestCase):

--- a/tests/mapping/test_configuration_map.py
+++ b/tests/mapping/test_configuration_map.py
@@ -91,9 +91,11 @@ class TestConfigurationMap(unittest.TestCase):
         config_map.add_configuration(test_config_2)
         config_map.add_configuration(test_config_3)
 
-        self.assertEqual(3, len(config_map.configurations()))
-        self.assertEqual([test_config_1, test_config_2, test_config_3],
-                         list(config_map.configurations()))
+        configurations = config_map.configurations()
+        self.assertEqual(3, len(configurations))
+        self.assertIn(test_config_1, configurations)
+        self.assertIn(test_config_2, configurations)
+        self.assertIn(test_config_3, configurations)
 
     def test_inter_id_config_tuples(self) -> None:
         """Test if we can iterate over all id configuration pairs."""
@@ -106,10 +108,11 @@ class TestConfigurationMap(unittest.TestCase):
         config_map.add_configuration(test_config_2)
         config_map.add_configuration(test_config_3)
 
-        self.assertEqual(3, len(config_map.id_config_tuples()))
-        self.assertEqual([(0, test_config_1), (1, test_config_2),
-                          (2, test_config_3)],
-                         list(config_map.id_config_tuples()))
+        id_config_tuples = config_map.id_config_tuples()
+        self.assertEqual(3, len(id_config_tuples))
+        self.assertIn((0, test_config_1), id_config_tuples)
+        self.assertIn((1, test_config_2), id_config_tuples)
+        self.assertIn((2, test_config_3), id_config_tuples)
 
 
 class TestConfigurationMapStoreAndLoad(unittest.TestCase):

--- a/varats-core/varats/base/configuration.py
+++ b/varats-core/varats/base/configuration.py
@@ -139,8 +139,9 @@ class Configuration:
             if len(self.options()) == len(other):
                 for option in self.options():
                     if option.name not in other:
-                        if not bool(option.value) == other:
-                            return False
+                        return False
+                    if not bool(option.value) == other[option.name]:
+                        return False
                 return True
         return False
 
@@ -183,7 +184,7 @@ class FrozenConfiguration(Configuration):
     def unfreeze(self) -> "Configuration":
         return deepcopy(self.__configuration)
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash(frozenset(self.options()))
 
 

--- a/varats-core/varats/base/configuration.py
+++ b/varats-core/varats/base/configuration.py
@@ -140,8 +140,11 @@ class Configuration:
                 for option in self.options():
                     if option.name not in other:
                         return False
-                    if bool(option.value) != other[option.name]:
-                        return False
+                    if isinstance(other[option.name], bool):
+                        return other[option.name
+                                    ]  # type: ignore [no-any-return]
+                    return option.value == other[
+                        option.name]  # type: ignore [no-any-return]
                 return True
         return False
 

--- a/varats-core/varats/base/configuration.py
+++ b/varats-core/varats/base/configuration.py
@@ -179,7 +179,7 @@ class FrozenConfiguration(Configuration):
         return self.__configuration.dump_to_string()
 
     def freeze(self) -> 'FrozenConfiguration':
-        raise NotImplementedError
+        return self
 
     def unfreeze(self) -> Configuration:
         return deepcopy(self.__configuration)
@@ -358,7 +358,7 @@ class ConfigurationImpl(Configuration):
         return FrozenConfiguration(deepcopy(self))
 
     def unfreeze(self) -> Configuration:
-        raise NotImplementedError
+        return self
 
 
 class PlainConfigurationOption(ConfigurationOptionImpl):
@@ -409,4 +409,4 @@ class PlainCommandlineConfiguration(Configuration):
         return None
 
     def unfreeze(self) -> Configuration:
-        raise NotImplementedError
+        return self

--- a/varats-core/varats/base/configuration.py
+++ b/varats-core/varats/base/configuration.py
@@ -44,7 +44,7 @@ class Configuration:
 
     @staticmethod
     @abc.abstractmethod
-    def create_configuration_from_str(config_str: str) -> "Configuration":
+    def create_configuration_from_str(config_str: str) -> 'Configuration':
         """
         Creates a `Configuration` from its string representation.
 
@@ -110,7 +110,7 @@ class Configuration:
         raise NotImplementedError  # pragma: no cover
 
     @abc.abstractmethod
-    def freeze(self) -> "FrozenConfiguration":
+    def freeze(self) -> 'FrozenConfiguration':
         """
         Returns an unmodifiable (hashable) version of the configuration. Useful
         when you want to add a 'Configuration' as key to a 'dict' or as element
@@ -121,7 +121,7 @@ class Configuration:
         raise NotImplementedError  # pragma: no cover
 
     @abc.abstractmethod
-    def unfreeze(self) -> "Configuration":
+    def unfreeze(self) -> 'Configuration':
         """
         Returns an unmodifiable (hashable) version of the configuration.
 
@@ -160,7 +160,7 @@ class FrozenConfiguration(Configuration):
         self.__configuration = configuration
 
     @staticmethod
-    def create_configuration_from_str(config_str: str) -> "Configuration":
+    def create_configuration_from_str(config_str: str) -> Configuration:
         raise NotImplementedError
 
     def options(self) -> tp.List[ConfigurationOption]:
@@ -178,10 +178,10 @@ class FrozenConfiguration(Configuration):
     def dump_to_string(self) -> str:
         return self.__configuration.dump_to_string()
 
-    def freeze(self) -> "FrozenConfiguration":
+    def freeze(self) -> 'FrozenConfiguration':
         raise NotImplementedError
 
-    def unfreeze(self) -> "Configuration":
+    def unfreeze(self) -> Configuration:
         return deepcopy(self.__configuration)
 
     def __hash__(self) -> int:
@@ -202,7 +202,7 @@ functionality. If a DummyConfiguration shows up in you configuration related
 part which accesses Configurations something is wrong with your setup."""
 
     @staticmethod
-    def create_configuration_from_str(config_str: str) -> "Configuration":
+    def create_configuration_from_str(config_str: str) -> Configuration:
         """
         Creates a `Configuration` from its string representation.
 
@@ -245,10 +245,10 @@ part which accesses Configurations something is wrong with your setup."""
         """
         raise AssertionError(DummyConfiguration.USAGE_ERROR_TEXT)
 
-    def freeze(self) -> "FrozenConfiguration":
+    def freeze(self) -> FrozenConfiguration:
         raise AssertionError(DummyConfiguration.USAGE_ERROR_TEXT)
 
-    def unfreeze(self) -> "Configuration":
+    def unfreeze(self) -> Configuration:
         raise AssertionError(DummyConfiguration.USAGE_ERROR_TEXT)
 
 
@@ -272,7 +272,7 @@ class ConfigurationImpl(Configuration):
     """A configuration of a software project."""
 
     @staticmethod
-    def create_configuration_from_str(config_str: str) -> "Configuration":
+    def create_configuration_from_str(config_str: str) -> Configuration:
         """
         Creates a `Configuration` from its string representation.
 
@@ -354,10 +354,10 @@ class ConfigurationImpl(Configuration):
             idx[1].name: idx[1].value for idx in self.__config_values.items()
         })
 
-    def freeze(self) -> "FrozenConfiguration":
+    def freeze(self) -> FrozenConfiguration:
         return FrozenConfiguration(deepcopy(self))
 
-    def unfreeze(self) -> "Configuration":
+    def unfreeze(self) -> Configuration:
         raise NotImplementedError
 
 
@@ -381,7 +381,7 @@ class PlainCommandlineConfiguration(Configuration):
         )
 
     @staticmethod
-    def create_configuration_from_str(config_str: str) -> "Configuration":
+    def create_configuration_from_str(config_str: str) -> Configuration:
         config_str_list = json.loads(config_str)
         return PlainCommandlineConfiguration(config_str_list)
 
@@ -408,5 +408,5 @@ class PlainCommandlineConfiguration(Configuration):
                 return option.value
         return None
 
-    def unfreeze(self) -> "Configuration":
+    def unfreeze(self) -> Configuration:
         raise NotImplementedError

--- a/varats-core/varats/base/configuration.py
+++ b/varats-core/varats/base/configuration.py
@@ -165,7 +165,7 @@ class FrozenConfiguration(Configuration):
         raise NotImplementedError
 
     def unfreeze(self) -> "Configuration":
-        return self.__configuration
+        return deepcopy(self.__configuration)
 
 
 class DummyConfiguration(Configuration):
@@ -226,10 +226,10 @@ part which accesses Configurations something is wrong with your setup."""
         raise AssertionError(DummyConfiguration.USAGE_ERROR_TEXT)
 
     def freeze(self) -> "FrozenConfiguration":
-        raise NotImplementedError
+        raise AssertionError(DummyConfiguration.USAGE_ERROR_TEXT)
 
     def unfreeze(self) -> "Configuration":
-        raise NotImplementedError
+        raise AssertionError(DummyConfiguration.USAGE_ERROR_TEXT)
 
 
 class ConfigurationOptionImpl(ConfigurationOption):
@@ -344,7 +344,7 @@ class ConfigurationImpl(Configuration):
 class PlainConfigurationOption(ConfigurationOptionImpl):
 
     def __init__(self, value: str) -> None:
-        super().__init__(name="UNKNOWN", value=value)
+        super().__init__(name=value.lstrip("-"), value=value)
 
 
 class PlainCommandlineConfiguration(Configuration):
@@ -377,13 +377,16 @@ class PlainCommandlineConfiguration(Configuration):
         return FrozenConfiguration(deepcopy(self))
 
     def add_config_option(self, option: ConfigurationOption) -> None:
-        raise NotImplementedError
+        self.__config_str_list.append(option)
 
     def set_config_option(self, option_name: str, value: str) -> None:
-        raise NotImplementedError
+        self.add_config_option(PlainConfigurationOption(value))
 
     def get_config_value(self, option_name: str) -> tp.Optional[tp.Any]:
-        raise NotImplementedError
+        for option in self.options():
+            if option.name == option_name:
+                return option.value
+        return None
 
     def unfreeze(self) -> "Configuration":
         raise NotImplementedError

--- a/varats-core/varats/base/configuration.py
+++ b/varats-core/varats/base/configuration.py
@@ -103,6 +103,15 @@ class Configuration():
         raise NotImplementedError  # pragma: no cover
 
     @abc.abstractmethod
+    def option_names(self) -> tp.List[str]:
+        """
+        Get all names of the configuration options.
+
+        Returns: a list of all configuration option names
+        """
+        raise NotImplementedError  # pragma: no cover
+
+    @abc.abstractmethod
     def dump_to_string(self) -> str:
         """
         Dumps the `Configuration` to a string.
@@ -113,6 +122,8 @@ class Configuration():
         Returns: Configuration as a string
         """
         raise NotImplementedError  # pragma: no cover
+
+    X = tp.TypeVar('X')
 
     def __iter__(self) -> tp.Iterator[ConfigurationOption]:
         for option in self.options():
@@ -165,6 +176,14 @@ part which accesses Configurations something is wrong with your setup."""
         Get all configuration options.
 
         Returns: a list of all configuration options
+        """
+        raise AssertionError(DummyConfiguration.USAGE_ERROR_TEXT)
+
+    def option_names(self) -> tp.List[str]:
+        """
+        Get all names of the configuration options.
+
+        Returns: a list of all configuration option names
         """
         raise AssertionError(DummyConfiguration.USAGE_ERROR_TEXT)
 
@@ -279,6 +298,9 @@ class ConfigurationImpl(Configuration):
         # Workaround mutable maps cannot be iterated yet
         # https://github.com/MagicStack/immutables/issues/55
         return list(self.__config_values.finish().values())
+
+    def option_names(self) -> tp.List[str]:
+        return [option.name for option in self.options()]
 
     def dump_to_string(self) -> str:
         if hasattr(self.__config_values, "values"):

--- a/varats-core/varats/base/configuration.py
+++ b/varats-core/varats/base/configuration.py
@@ -103,15 +103,6 @@ class Configuration():
         raise NotImplementedError  # pragma: no cover
 
     @abc.abstractmethod
-    def option_names(self) -> tp.List[str]:
-        """
-        Get all names of the configuration options.
-
-        Returns: a list of all configuration option names
-        """
-        raise NotImplementedError  # pragma: no cover
-
-    @abc.abstractmethod
     def dump_to_string(self) -> str:
         """
         Dumps the `Configuration` to a string.
@@ -122,8 +113,6 @@ class Configuration():
         Returns: Configuration as a string
         """
         raise NotImplementedError  # pragma: no cover
-
-    X = tp.TypeVar('X')
 
     def __iter__(self) -> tp.Iterator[ConfigurationOption]:
         for option in self.options():
@@ -176,14 +165,6 @@ part which accesses Configurations something is wrong with your setup."""
         Get all configuration options.
 
         Returns: a list of all configuration options
-        """
-        raise AssertionError(DummyConfiguration.USAGE_ERROR_TEXT)
-
-    def option_names(self) -> tp.List[str]:
-        """
-        Get all names of the configuration options.
-
-        Returns: a list of all configuration option names
         """
         raise AssertionError(DummyConfiguration.USAGE_ERROR_TEXT)
 
@@ -298,9 +279,6 @@ class ConfigurationImpl(Configuration):
         # Workaround mutable maps cannot be iterated yet
         # https://github.com/MagicStack/immutables/issues/55
         return list(self.__config_values.finish().values())
-
-    def option_names(self) -> tp.List[str]:
-        return [option.name for option in self.options()]
 
     def dump_to_string(self) -> str:
         if hasattr(self.__config_values, "values"):

--- a/varats-core/varats/base/configuration.py
+++ b/varats-core/varats/base/configuration.py
@@ -3,6 +3,13 @@ varats-* libraries."""
 import abc
 import json
 import typing as tp
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import Any
+
+# Can be removed once https://peps.python.org/pep-0603/ is resolved.
+from immutables import Map as FrozenMap
+from immutables import MapMutation
 
 
 class ConfigurationOption():
@@ -96,6 +103,15 @@ class Configuration():
         raise NotImplementedError  # pragma: no cover
 
     @abc.abstractmethod
+    def option_names(self) -> tp.List[str]:
+        """
+        Get all names of the configuration options.
+
+        Returns: a list of all configuration option names
+        """
+        raise NotImplementedError  # pragma: no cover
+
+    @abc.abstractmethod
     def dump_to_string(self) -> str:
         """
         Dumps the `Configuration` to a string.
@@ -106,6 +122,12 @@ class Configuration():
         Returns: Configuration as a string
         """
         raise NotImplementedError  # pragma: no cover
+
+    X = tp.TypeVar('X')
+
+    def __iter__(self) -> tp.Iterator[ConfigurationOption]:
+        for option in self.options():
+            yield option
 
     def __str__(self) -> str:
         return self.dump_to_string()
@@ -125,7 +147,7 @@ functionality. If a DummyConfiguration shows up in you configuration related
 part which accesses Configurations something is wrong with your setup."""
 
     @staticmethod
-    def create_configuration_from_str(config_str: str) -> 'Configuration':
+    def create_configuration_from_str(config_str: str) -> Configuration:
         """
         Creates a `Configuration` from its string representation.
 
@@ -157,6 +179,14 @@ part which accesses Configurations something is wrong with your setup."""
         """
         raise AssertionError(DummyConfiguration.USAGE_ERROR_TEXT)
 
+    def option_names(self) -> tp.List[str]:
+        """
+        Get all names of the configuration options.
+
+        Returns: a list of all configuration option names
+        """
+        raise AssertionError(DummyConfiguration.USAGE_ERROR_TEXT)
+
     def dump_to_string(self) -> str:
         """
         Dumps the `Configuration` to a string.
@@ -169,27 +199,39 @@ part which accesses Configurations something is wrong with your setup."""
         raise AssertionError(DummyConfiguration.USAGE_ERROR_TEXT)
 
 
+@dataclass(frozen=True)
 class ConfigurationOptionImpl(ConfigurationOption):
     """A configuration option of a software project."""
 
-    def __init__(self, name: str, value: tp.Any) -> None:
-        self.__name = name
-        self.__value = value
+    _name: str
+    _value: tp.Any
 
     @property
     def name(self) -> str:
-        return self.__name
+        return self._name
 
     @property
     def value(self) -> tp.Any:
-        return self.__value
+        return self._value
+
+
+def make_possible_type_conversion(option_value: str) -> tp.Any:
+    """Converts string to correct type for special cases like bool or None."""
+    if option_value.lower() == "true":
+        return True
+    if option_value.lower() == "false":
+        return False
+    if option_value.lower() == "none":
+        return None
+
+    return option_value
 
 
 class ConfigurationImpl(Configuration):
     """A configuration of a software project."""
 
     @staticmethod
-    def create_configuration_from_str(config_str: str) -> 'Configuration':
+    def create_configuration_from_str(config_str: str) -> Configuration:
         """
         Creates a `Configuration` from its string representation.
 
@@ -201,18 +243,6 @@ class ConfigurationImpl(Configuration):
         loaded_dict = json.loads(config_str)
         config = ConfigurationImpl()
         for option_name, option_value in loaded_dict.items():
-
-            def make_possible_type_conversion(option_value: str) -> tp.Any:
-                """Converts string to correct type for special cases like bool
-                or None."""
-                if option_value.lower() == "true":
-                    return True
-                if option_value.lower() == "false":
-                    return False
-                if option_value.lower() == "none":
-                    return None
-
-                return option_value
 
             if option_value is not False and option_value is not True and \
                     not isinstance(option_value, int):
@@ -226,7 +256,8 @@ class ConfigurationImpl(Configuration):
         return config
 
     def __init__(self) -> None:
-        self.__config_values: tp.Dict[str, ConfigurationOption] = {}
+        self.__config_values: tp.Union[MapMutation,
+                                       FrozenMap] = FrozenMap().mutate()
 
     def add_config_option(self, option: ConfigurationOption) -> None:
         """
@@ -262,21 +293,82 @@ class ConfigurationImpl(Configuration):
         return None
 
     def options(self) -> tp.List[ConfigurationOption]:
-        return list(self.__config_values.values())
+        if hasattr(self.__config_values, "values"):
+            return list(self.__config_values.values())
+        # Workaround mutable maps cannot be iterated yet
+        # https://github.com/MagicStack/immutables/issues/55
+        return list(self.__config_values.finish().values())
+
+    def option_names(self) -> tp.List[str]:
+        return [option.name for option in self.options()]
 
     def dump_to_string(self) -> str:
+        if hasattr(self.__config_values, "values"):
+            return json.dumps({
+                idx[1].name: idx[1].value
+                for idx in self.__config_values.items()
+            })
+        # Workaround mutable maps cannot be iterated yet
+        # https://github.com/MagicStack/immutables/issues/55
         return json.dumps({
-            idx[1].name: idx[1].value for idx in self.__config_values.items()
+            idx[1].name: idx[1].value
+            for idx in self.__config_values.finish().items()
         })
+
+    def freeze(self) -> 'FrozenConfigurationImpl':
+        self.__config_values = self.__config_values.finish()
+        return FrozenConfigurationImpl(self)
+
+    def unfreeze(self) -> None:
+        self.__config_values = self.__config_values.mutate()
+
+
+class FrozenConfigurationImpl:
+    """Same as ConfigurationImpl but hashable."""
+
+    def __init__(self, configuration_impl: ConfigurationImpl) -> None:
+        self.configuration_impl = configuration_impl
+
+    def __getattr__(self, __name: str) -> Any:
+        return getattr(
+            self.configuration_impl,
+            __name.replace(self.__class__.__name__, ConfigurationImpl.__name__)
+        )
+
+    def __hash__(self) -> tp.Any:
+        return self.__config_values.__hash__()
+
+    def __deepcopy__(self, memo) -> ConfigurationImpl:
+        result = deepcopy(self.configuration_impl, memo)
+        result.unfreeze()
+        return result
+
+    def add_config_option(self, option: ConfigurationOption) -> None:
+        raise NotImplementedError
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, tp.Mapping):
+            if len(self.__config_values) != len(other):
+                return False
+            for item in self.__config_values:
+                if item not in other:
+                    return False
+            return True
+        return False
+
+    def __iter__(self) -> tp.Iterator[ConfigurationOption]:
+        for option in self.options():
+            yield option
 
 
 class PlainConfigurationOption(ConfigurationOptionImpl):
+    """A configuration option from plain text."""
 
     def __init__(self, value: str) -> None:
-        super().__init__(name="UNKNOWN", value=value)
+        super().__init__(value.lstrip("-"), value)
 
 
-class PlainCommandlineConfiguration(Configuration):
+class PlainCommandlineConfiguration(ConfigurationImpl):
     """
     Simple configuration format where command line args are directly written
     into the file.
@@ -285,28 +377,14 @@ class PlainCommandlineConfiguration(Configuration):
     """
 
     def __init__(self, config_str_list: tp.List[str]) -> None:
-        self.__config_str_list: tp.List[ConfigurationOption] = list(
-            map(PlainConfigurationOption, config_str_list)
-        )
+        super().__init__()
+        for config_str in config_str_list:
+            self.add_config_option(PlainConfigurationOption(config_str))
 
     @staticmethod
-    def create_configuration_from_str(config_str: str) -> 'Configuration':
+    def create_configuration_from_str(config_str: str) -> Configuration:
         config_str_list = json.loads(config_str)
         return PlainCommandlineConfiguration(config_str_list)
 
     def dump_to_string(self) -> str:
-        return " ".join(
-            map(lambda option: option.value, self.__config_str_list)
-        )
-
-    def options(self) -> tp.List[ConfigurationOption]:
-        return self.__config_str_list
-
-    def add_config_option(self, option: ConfigurationOption) -> None:
-        raise NotImplementedError
-
-    def set_config_option(self, option_name: str, value: str) -> None:
-        raise NotImplementedError
-
-    def get_config_value(self, option_name: str) -> tp.Optional[tp.Any]:
-        raise NotImplementedError
+        return " ".join(map(lambda option: option.value, self.options()))

--- a/varats-core/varats/base/configuration.py
+++ b/varats-core/varats/base/configuration.py
@@ -140,7 +140,7 @@ class Configuration:
                 for option in self.options():
                     if option.name not in other:
                         return False
-                    if not bool(option.value) == other[option.name]:
+                    if bool(option.value) != other[option.name]:
                         return False
                 return True
         return False

--- a/varats-core/varats/base/configuration.py
+++ b/varats-core/varats/base/configuration.py
@@ -19,7 +19,7 @@ class ConfigurationOption:
 
     @property
     @abc.abstractmethod
-    def value(self) -> str:
+    def value(self) -> tp.Any:
         """Currently set value of the option."""
         raise NotImplementedError  # pragma: no cover
 
@@ -66,7 +66,7 @@ class Configuration:
         raise NotImplementedError  # pragma: no cover
 
     @abc.abstractmethod
-    def set_config_option(self, option_name: str, value: str) -> None:
+    def set_config_option(self, option_name: str, value: tp.Any) -> None:
         """
         Sets the value of a `ConfigurationOption` with the corresponding key.
 
@@ -169,7 +169,7 @@ class FrozenConfiguration(Configuration):
     def add_config_option(self, option: ConfigurationOption) -> None:
         raise NotImplementedError
 
-    def set_config_option(self, option_name: str, value: str) -> None:
+    def set_config_option(self, option_name: str, value: tp.Any) -> None:
         raise NotImplementedError
 
     def get_config_value(self, option_name: str) -> tp.Optional[tp.Any]:
@@ -217,11 +217,11 @@ part which accesses Configurations something is wrong with your setup."""
         """The dummy configuration does not add config options."""
         raise AssertionError(DummyConfiguration.USAGE_ERROR_TEXT)
 
-    def set_config_option(self, option_name: str, value: str) -> None:
+    def set_config_option(self, option_name: str, value: tp.Any) -> None:
         """The dummy configuration does not set config options."""
         raise AssertionError(DummyConfiguration.USAGE_ERROR_TEXT)
 
-    def get_config_value(self, option_name: str) -> tp.Optional[str]:
+    def get_config_value(self, option_name: str) -> tp.Optional[tp.Any]:
         """The dummy configuration does provide direct access to the
         configuration options."""
         raise AssertionError(DummyConfiguration.USAGE_ERROR_TEXT)
@@ -322,7 +322,7 @@ class ConfigurationImpl(Configuration):
         """
         self.__config_values[option.name] = option
 
-    def set_config_option(self, option_name: str, value: str) -> None:
+    def set_config_option(self, option_name: str, value: tp.Any) -> None:
         """
         Sets the value of a `ConfigurationOption` with the corresponding key.
 
@@ -332,7 +332,7 @@ class ConfigurationImpl(Configuration):
         """
         self.add_config_option(ConfigurationOptionImpl(option_name, value))
 
-    def get_config_value(self, option_name: str) -> tp.Optional[str]:
+    def get_config_value(self, option_name: str) -> tp.Optional[tp.Any]:
         """
         Returns the set value for the given feature.
 
@@ -387,7 +387,7 @@ class PlainCommandlineConfiguration(Configuration):
 
     def dump_to_string(self) -> str:
         return " ".join(
-            map(lambda option: option.value, self.__config_str_list)
+            map(lambda option: str(option.value), self.__config_str_list)
         )
 
     def options(self) -> tp.List[ConfigurationOption]:
@@ -399,7 +399,7 @@ class PlainCommandlineConfiguration(Configuration):
     def add_config_option(self, option: ConfigurationOption) -> None:
         self.__config_str_list.append(option)
 
-    def set_config_option(self, option_name: str, value: str) -> None:
+    def set_config_option(self, option_name: str, value: tp.Any) -> None:
         self.add_config_option(ConfigurationOptionImpl(option_name, value))
 
     def get_config_value(self, option_name: str) -> tp.Optional[tp.Any]:

--- a/varats-core/varats/base/configuration.py
+++ b/varats-core/varats/base/configuration.py
@@ -141,10 +141,11 @@ class Configuration:
                     if option.name not in other:
                         return False
                     if isinstance(other[option.name], bool):
-                        return other[option.name
-                                    ]  # type: ignore [no-any-return]
-                    return option.value == other[
-                        option.name]  # type: ignore [no-any-return]
+                        if bool(option.value) != other[option.name]:
+                            return False
+                    else:
+                        if option.value != other[option.name]:
+                            return False
                 return True
         return False
 


### PR DESCRIPTION
Our configurations are currently not hashable because they contain mutable objects, e.g `dict` or `list`. Therefore, they cannot be used as a key in a `dict` or as element in a `set` which limits their usability.
For example, in my other PR https://github.com/se-sic/VaRA-Tool-Suite/pull/718 I need a mapping from `Configuration -> Reports`. Currently my workaround was to rewrite my own immutable configuration class to make that work: https://github.com/se-sic/VaRA-Tool-Suite/pull/718/files#diff-46ee8773a540aedfd0d1cfbb2d2721a6191d64d3868c538d282c34f85a048492R50. But that basically duplicates functionality and it would be nice to reuse our existing configuration classes for that.
However, a lot of our code relies on the mutability of configurations. Therefore, my proposal is to keep configurations mutable by default but make them immutable (freeze them) on demand. The [immutables.map](https://github.com/MagicStack/immutables) datatype provides these properties.

The committed code is a rough and far from perfect sketch how such a solution could look like. Apart from loosing the insertion order of configuration options it passes all tests. But I would like to collect some opinions first before pursuing this.