### PR TITLE
Fix multi case study plots and tables

### DIFF
--- a/varats/varats/plot/plot.py
+++ b/varats/varats/plot/plot.py
@@ -155,8 +155,9 @@ class Plot:
             if isinstance(case_study, varats.paper.case_study.CaseStudy):
                 plot_ident = f"{case_study.project_name}_{case_study.version}_"
             else:
-                plot_ident = \
-                f"{reduce(lambda x,y: f'{x}{y.project_name}_',case_study,'')}"
+                plot_ident = reduce(
+                    lambda x, y: f'{x}{y.project_name}_', case_study, ''
+                )
         elif 'project' in self.plot_kwargs:
             plot_ident = f"{self.plot_kwargs['project']}_"
 

--- a/varats/varats/plot/plot.py
+++ b/varats/varats/plot/plot.py
@@ -155,7 +155,8 @@ class Plot:
             if isinstance(case_study, varats.paper.case_study.CaseStudy):
                 plot_ident = f"{case_study.project_name}_{case_study.version}_"
             else:
-                plot_ident = f"{reduce(lambda x,y: f'{x}{y.project_name}_',case_study,'')}"
+                plot_ident = \
+                    f"{reduce(lambda x,y: f'{x}{y.project_name}_',case_study,'')}"
         elif 'project' in self.plot_kwargs:
             plot_ident = f"{self.plot_kwargs['project']}_"
 

--- a/varats/varats/plot/plot.py
+++ b/varats/varats/plot/plot.py
@@ -156,7 +156,7 @@ class Plot:
                 plot_ident = f"{case_study.project_name}_{case_study.version}_"
             else:
                 plot_ident = \
-                    f"{reduce(lambda x,y: f'{x}{y.project_name}_',case_study,'')}"
+                f"{reduce(lambda x,y: f'{x}{y.project_name}_',case_study,'')}"
         elif 'project' in self.plot_kwargs:
             plot_ident = f"{self.plot_kwargs['project']}_"
 

--- a/varats/varats/plot/plot.py
+++ b/varats/varats/plot/plot.py
@@ -3,10 +3,12 @@
 import abc
 import logging
 import typing as tp
+from functools import reduce
 from pathlib import Path
 
 import matplotlib.pyplot as plt
 
+import varats.paper.case_study
 from varats.plot.plots import PlotConfig
 from varats.utils.git_util import FullCommitHash
 
@@ -149,8 +151,11 @@ class Plot:
         """
         plot_ident = ''
         if 'case_study' in self.plot_kwargs:
-            case_study: 'CaseStudy' = self.plot_kwargs['case_study']
-            plot_ident = f"{case_study.project_name}_{case_study.version}_"
+            case_study = self.plot_kwargs['case_study']
+            if isinstance(case_study, varats.paper.case_study.CaseStudy):
+                plot_ident = f"{case_study.project_name}_{case_study.version}_"
+            else:
+                plot_ident = f"{reduce(lambda x,y: f'{x}{y.project_name}_',case_study,'')}"
         elif 'project' in self.plot_kwargs:
             plot_ident = f"{self.plot_kwargs['project']}_"
 

--- a/varats/varats/table/table.py
+++ b/varats/varats/table/table.py
@@ -153,7 +153,8 @@ class Table:
             if isinstance(case_study, varats.paper.case_study.CaseStudy):
                 table_ident = f"{case_study.project_name}_{case_study.version}_"
             else:
-                table_ident = f"{reduce(lambda x, y: f'{x}{y.project_name}_', case_study, '')}"
+                table_ident = \
+                    f"{reduce(lambda x, y: f'{x}{y.project_name}_', case_study, '')}"
         elif 'project' in self.table_kwargs:
             table_ident = f"{self.table_kwargs['project']}_"
 

--- a/varats/varats/table/table.py
+++ b/varats/varats/table/table.py
@@ -153,8 +153,9 @@ class Table:
             if isinstance(case_study, varats.paper.case_study.CaseStudy):
                 table_ident = f"{case_study.project_name}_{case_study.version}_"
             else:
-                table_ident = \
-            f"{reduce(lambda x, y: f'{x}{y.project_name}_', case_study, '')}"
+                table_ident = reduce(
+                    lambda x, y: f'{x}{y.project_name}_', case_study, ''
+                )
         elif 'project' in self.table_kwargs:
             table_ident = f"{self.table_kwargs['project']}_"
 

--- a/varats/varats/table/table.py
+++ b/varats/varats/table/table.py
@@ -154,7 +154,7 @@ class Table:
                 table_ident = f"{case_study.project_name}_{case_study.version}_"
             else:
                 table_ident = \
-                f"{reduce(lambda x, y: f'{x}{y.project_name}_', case_study, '')}"
+            f"{reduce(lambda x, y: f'{x}{y.project_name}_', case_study, '')}"
         elif 'project' in self.table_kwargs:
             table_ident = f"{self.table_kwargs['project']}_"
 

--- a/varats/varats/table/table.py
+++ b/varats/varats/table/table.py
@@ -154,7 +154,7 @@ class Table:
                 table_ident = f"{case_study.project_name}_{case_study.version}_"
             else:
                 table_ident = \
-                    f"{reduce(lambda x, y: f'{x}{y.project_name}_', case_study, '')}"
+                f"{reduce(lambda x, y: f'{x}{y.project_name}_', case_study, '')}"
         elif 'project' in self.table_kwargs:
             table_ident = f"{self.table_kwargs['project']}_"
 

--- a/varats/varats/table/table.py
+++ b/varats/varats/table/table.py
@@ -3,8 +3,10 @@
 import abc
 import logging
 import typing as tp
+from functools import reduce
 from pathlib import Path
 
+import varats.paper.case_study
 from varats.table.tables import TableFormat, TableConfig
 
 if tp.TYPE_CHECKING:
@@ -147,8 +149,11 @@ class Table:
         """
         table_ident = ''
         if 'case_study' in self.table_kwargs:
-            case_study: 'CaseStudy' = self.table_kwargs['case_study']
-            table_ident = f"{case_study.project_name}_{case_study.version}_"
+            case_study = self.table_kwargs['case_study']
+            if isinstance(case_study, varats.paper.case_study.CaseStudy):
+                table_ident = f"{case_study.project_name}_{case_study.version}_"
+            else:
+                table_ident = f"{reduce(lambda x, y: f'{x}{y.project_name}_', case_study, '')}"
         elif 'project' in self.table_kwargs:
             table_ident = f"{self.table_kwargs['project']}_"
 


### PR DESCRIPTION
Plots and tables containing multiple case studies no longer crash when generating the filename.
Their file name is now based on all projects in the provided case studies