### PR TITLE
Adapts git util error message and includes more file extensions

### DIFF
--- a/tests/table/test_case_study_metrics_table.py
+++ b/tests/table/test_case_study_metrics_table.py
@@ -30,7 +30,7 @@ class TestCSMetricsTable(unittest.TestCase):
 \toprule
  & Domain & LOC (repo) & LOC (project) & Commits & Authors & Revision \\
 \midrule
-brotli & Compression & 34\,639 & 34\,639 & 848 & 40 & aaa4424d9b \\
+brotli & Compression & 35\,662 & 35\,662 & 848 & 40 & aaa4424d9b \\
 \bottomrule
 \end{tabular}
 """, table_str

--- a/tests/utils/test_git_util.py
+++ b/tests/utils/test_git_util.py
@@ -273,15 +273,15 @@ class TestChurnConfig(unittest.TestCase):
         c_style_config = ChurnConfig.create_c_style_languages_config()
         self.assertEqual(
             c_style_config.get_extensions_repr(),
-            ["c", "cpp", "cxx", "h", "hpp", "hxx"]
+            ["c", "cc", "cpp", "cxx", "h", "hpp", "hxx"]
         )
         self.assertEqual(
             c_style_config.get_extensions_repr(prefix="*."),
-            ["*.c", "*.cpp", "*.cxx", "*.h", "*.hpp", "*.hxx"]
+            ["*.c", "*.cc", "*.cpp", "*.cxx", "*.h", "*.hpp", "*.hxx"]
         )
         self.assertEqual(
             c_style_config.get_extensions_repr(suffix="|"),
-            ["c|", "cpp|", "cxx|", "h|", "hpp|", "hxx|"]
+            ["c|", "cc|", "cpp|", "cxx|", "h|", "hpp|", "hxx|"]
         )
 
 

--- a/varats-core/varats/utils/git_util.py
+++ b/varats-core/varats/utils/git_util.py
@@ -37,7 +37,9 @@ class CommitHash(abc.ABC):
 
     def __init__(self, short_commit_hash: str):
         if not len(short_commit_hash) >= self.hash_length():
-            raise ValueError(f"Commit hash too short, only got {short_commit_hash}")
+            raise ValueError(
+                f"Commit hash too short, only got {short_commit_hash}"
+            )
         self.__commit_hash = short_commit_hash[:self.hash_length()]
 
     @property

--- a/varats-core/varats/utils/git_util.py
+++ b/varats-core/varats/utils/git_util.py
@@ -37,7 +37,7 @@ class CommitHash(abc.ABC):
 
     def __init__(self, short_commit_hash: str):
         if not len(short_commit_hash) >= self.hash_length():
-            raise ValueError(f"Commit hash too short {short_commit_hash}")
+            raise ValueError(f"Commit hash too short, only got {short_commit_hash}")
         self.__commit_hash = short_commit_hash[:self.hash_length()]
 
     @property

--- a/varats-core/varats/utils/git_util.py
+++ b/varats-core/varats/utils/git_util.py
@@ -37,7 +37,7 @@ class CommitHash(abc.ABC):
 
     def __init__(self, short_commit_hash: str):
         if not len(short_commit_hash) >= self.hash_length():
-            raise ValueError("Commit hash too short")
+            raise ValueError(f"Commit hash too short {short_commit_hash}")
         self.__commit_hash = short_commit_hash[:self.hash_length()]
 
     @property

--- a/varats-core/varats/utils/git_util.py
+++ b/varats-core/varats/utils/git_util.py
@@ -474,7 +474,7 @@ class ChurnConfig():
         value: tp.Set[str]  # pylint: disable=invalid-name
 
         C = {"h", "c"}
-        CPP = {"h", "hxx", "hpp", "cxx", "cpp"}
+        CPP = {"h", "hxx", "hpp", "cxx", "cpp", "cc"}
 
     def __init__(self) -> None:
         self.__enabled_languages: tp.List[ChurnConfig.Language] = []


### PR DESCRIPTION
Includes the provided commit hash in the error message for a to short commit hash when creating a CommitHash object.
Adds .cc as possible extension for c++ files.