### PR TITLE
Minor improvements to PatchSet

### DIFF
--- a/varats-core/varats/provider/patch/patch_provider.py
+++ b/varats-core/varats/provider/patch/patch_provider.py
@@ -223,6 +223,12 @@ class PatchSet:
 
     def __init__(self, patches: tp.Set[Patch]):
         self.__patches: tp.FrozenSet[Patch] = frozenset(patches)
+        tags: tp.Optional[tp.Set[str]] = set()
+
+        for p in patches:
+            tags.update(p.tags) if p.tags else None
+
+        self.__tags = frozenset(tags)
 
     def __iter__(self) -> tp.Iterator[Patch]:
         return self.__patches.__iter__()
@@ -235,23 +241,41 @@ class PatchSet:
 
     def __getitem__(self, tag):
         tag_set = set(tag)
-        return PatchSet({p for p in self.__patches if tag_set.issubset(p.tags)})
+        res_set = set()
+
+        for patch in self.__patches:
+            if patch.tags and tag_set.issubset(patch.tags):
+                res_set.add(patch)
+
+        return PatchSet(res_set)
 
     def __and__(self, rhs: "PatchSet") -> "PatchSet":
-        lhs_t = self.__patches
-        rhs_t = rhs.__patches
+        lhs_tags = self.__tags
+        rhs_tags = rhs.__tags
 
-        ret = {}
-        ...
-        return ret
+        tags: tp.FrozenSet[str] = lhs_tags.intersection(rhs_tags)
+
+        ret: tp.Set[Patch] = set()
+
+        for patch in self.__patches:
+            if patch.tags and any([tag in patch.tags for tag in tags]):
+                ret.add(patch)
+
+        return PatchSet(ret)
 
     def __or__(self, rhs: "PatchSet") -> "PatchSet":
-        lhs_t = self.__patches
-        rhs_t = rhs.__patches
+        lhs_t = self.__tags
+        rhs_t = rhs.__tags
 
-        ret = {}
-        ...
-        return ret
+        tags: tp.FrozenSet[str] = lhs_t.union(rhs_t)
+
+        ret = set()
+
+        for patch in self.__patches:
+            if patch.tags and any([tag in patch.tags for tag in tags]):
+                ret.add(patch)
+
+        return PatchSet(ret)
 
     def __hash__(self) -> int:
         return hash(self.__patches)

--- a/varats-core/varats/provider/patch/patch_provider.py
+++ b/varats-core/varats/provider/patch/patch_provider.py
@@ -112,13 +112,13 @@ class Patch:
     """A class for storing a single project-specific Patch."""
 
     def __init__(
-            self,
-            project_name: str,
-            shortname: str,
-            description: str,
-            path: Path,
-            valid_revisions: tp.Optional[tp.Set[CommitHash]] = None,
-            tags: tp.Optional[tp.Set[str]] = None
+        self,
+        project_name: str,
+        shortname: str,
+        description: str,
+        path: Path,
+        valid_revisions: tp.Optional[tp.Set[CommitHash]] = None,
+        tags: tp.Optional[tp.Set[str]] = None
     ):
         self.project_name: str = project_name
         self.shortname: str = shortname
@@ -190,7 +190,7 @@ class Patch:
             include_revisions = {
                 ShortCommitHash(h)
                 for h in main_repo_git('log', '--pretty=%H', '--first-parent'
-                                       ).strip().split()
+                                      ).strip().split()
             }
 
         if "exclude_revisions" in yaml_dict:
@@ -207,7 +207,7 @@ class Patch:
 
     def __str__(self) -> str:
         valid_revs = [str(r) for r in self.valid_revisions
-                      ] if self.valid_revisions else []
+                     ] if self.valid_revisions else []
         str_representation = f"""Patch(
     ProjectName: {self.project_name}
     Shortname: {self.shortname}
@@ -223,9 +223,8 @@ class Patch:
 
 
 class PatchSet:
-    """
-    A PatchSet is a storage container for project specific patches that can easily be accessed via the tags of a patch
-    """
+    """A PatchSet is a storage container for project specific patches that can
+    easily be accessed via the tags of a patch."""
 
     def __init__(self, patches: tp.Set[Patch]):
         self.__patches: tp.FrozenSet[Patch] = frozenset(patches)
@@ -241,7 +240,7 @@ class PatchSet:
 
     def __getitem__(self, tags: tp.Union[str, tp.Iterable[str]]):
         """
-        Overrides the bracket operator of a PatchSet
+        Overrides the bracket operator of a PatchSet.
 
         Returns a PatchSet, such that all patches include all the tags given
         """
@@ -266,15 +265,12 @@ class PatchSet:
         return PatchSet(self.__patches.intersection(rhs.__patches))
 
     def __or__(self, rhs: "PatchSet") -> "PatchSet":
-        """
-        Implementing the union of two sets
-        """
+        """Implementing the union of two sets."""
         return PatchSet(self.__patches.union(rhs.__patches))
 
     def any_of(self, tags: tp.Union[str, tp.Iterable[str]]) -> "PatchSet":
-        """
-        Returns a patch set with patches containing at least one of the given tags
-        """
+        """Returns a patch set with patches containing at least one of the given
+        tags."""
         # Trick to handle just a single tag being passed
         if isinstance(tags, str):
             tags = [tags]
@@ -286,9 +282,9 @@ class PatchSet:
 
         return PatchSet(result)
 
-    def all_of(self, tags: tp.Union[str, tp.Iterable[str]]) -> "PatchSet" :
+    def all_of(self, tags: tp.Union[str, tp.Iterable[str]]) -> "PatchSet":
         """
-        Returns a patch set with patches containing all the given tags
+        Returns a patch set with patches containing all the given tags.
 
         Equivalent to bracket operator (__getitem__)
         """
@@ -356,7 +352,7 @@ class PatchProvider(Provider):
 
     @classmethod
     def create_provider_for_project(
-            cls: tp.Type[ProviderType], project: tp.Type[Project]
+        cls: tp.Type[ProviderType], project: tp.Type[Project]
     ):
         """
         Creates a provider instance for the given project if possible.
@@ -373,7 +369,7 @@ class PatchProvider(Provider):
 
     @classmethod
     def create_default_provider(
-            cls: tp.Type[ProviderType], project: tp.Type[Project]
+        cls: tp.Type[ProviderType], project: tp.Type[Project]
     ):
         """
         Creates a default provider instance that can be used with any project.

--- a/varats-core/varats/provider/patch/patch_provider.py
+++ b/varats-core/varats/provider/patch/patch_provider.py
@@ -218,6 +218,9 @@ class Patch:
 
         return str_representation
 
+    def __hash__(self):
+        return hash((self.shortname, str(self.path), self.tags))
+
 
 class PatchSet:
     """


### PR DESCRIPTION
Add proper intersection and union operations to the PatchSet. I tinkered around a bit with the intersection being somewhat based on the tags occuring in both PatchSets, but in the end the classic intersection seems like the best option.

We could discuss whether we want to actually override `getitem` and so, what the behavior of it should be. Currently, it behaves like `all_of`.