### PR TITLE
Switches year iteration order in revs_per_year cs extender.

### DIFF
--- a/tests/paper_mgmt/test_case_study.py
+++ b/tests/paper_mgmt/test_case_study.py
@@ -246,6 +246,7 @@ class TestCaseStudyRevisionLookupFunctions(unittest.TestCase):
 
 class TestCaseStudyExtenders(unittest.TestCase):
 
+    @run_in_test_environment()
     def test_extend_with_revs_per_year(self) -> None:
         initialize_projects()
         random.seed(42)
@@ -260,12 +261,12 @@ class TestCaseStudyExtenders(unittest.TestCase):
         self.assertEqual(cs.num_stages, 17)
         self.assertEqual(len(cs.revisions), 31)
         self.assertEqual(
-            cs.get_stage_by_name('2022').revisions[0],
-            FullCommitHash("8fd225a2c149f30aeac377e68eb5abf6b28300ad")
+            FullCommitHash("f82294c8318a7a0990583d51ac5c7de682ad36ef"),
+            cs.get_stage_by_name("2022").revisions[0],
         )
         self.assertEqual(
-            cs.revisions[-1],
-            FullCommitHash("ec490da5228263b25bf786bb23d1008468f55b30")
+            FullCommitHash("320601b2c7b08fc7da9da18d5bf7c3c1a189b080"),
+            cs.revisions[-1]
         )
 
     @run_in_test_environment(

--- a/varats/varats/paper_mgmt/case_study.py
+++ b/varats/varats/paper_mgmt/case_study.py
@@ -506,7 +506,9 @@ def extend_with_revs_per_year(
         )
 
     new_rev_items = []  # new revisions that get added to case_study
-    for year, commits_in_year in commits.items():
+    for year, commits_in_year in sorted(
+        commits.items(), key=lambda entry: entry[0]
+    ):
         samples = min(len(commits_in_year), revs_per_year)
         sample_commit_indices = sorted(
             random.sample(range(len(commits_in_year)), samples)


### PR DESCRIPTION
In Python, random.sample() results seem to depend on the size of the sampled range and the number of drawn samples. This caused the sample to become unstable when a repo adds new commits. This change should ensure that the sample for all years but the current one remain stable.