### PR TITLE
Add requires attribute to Command

### DIFF
--- a/tests/experiment/test_workload_util.py
+++ b/tests/experiment/test_workload_util.py
@@ -1,6 +1,5 @@
 """Test VaRA workload utilities."""
 import unittest
-from copy import deepcopy
 from pathlib import Path
 
 from benchbuild.command import Command, PathToken, RootRenderer

--- a/tests/experiment/test_workload_util.py
+++ b/tests/experiment/test_workload_util.py
@@ -55,7 +55,7 @@ class TestWorkloadCommands(unittest.TestCase):
 
     def test_workload_commands_requires(self) -> None:
         revision = Revision(Xz, Variant(Xz.SOURCE[0], "c5c7ceb08a"))
-        project = deepcopy(Xz(revision=revision))
+        project = Xz(revision=revision)
         binary = Xz.binaries_for_revision(ShortCommitHash("c5c7ceb08a"))[0]
 
         commands = wu.workload_commands(

--- a/tests/experiment/test_workload_util.py
+++ b/tests/experiment/test_workload_util.py
@@ -2,7 +2,6 @@
 import unittest
 from copy import deepcopy
 from pathlib import Path
-from unittest.mock import patch
 
 from benchbuild.command import Command, PathToken, RootRenderer
 from benchbuild.source.base import Revision, Variant
@@ -59,24 +58,14 @@ class TestWorkloadCommands(unittest.TestCase):
         project = deepcopy(Xz(revision=revision))
         binary = Xz.binaries_for_revision(ShortCommitHash("c5c7ceb08a"))[0]
 
-        commands = next(
-            wu.filter_workload_index(
-                wu.WorkloadSet(wu.WorkloadCategory.EXAMPLE), project.workloads
-            )
-        )
-        commands[0]._requires = {"--compress"}
         commands = wu.workload_commands(
             project, binary, [wu.WorkloadCategory.EXAMPLE]
         )
-        self.assertEqual(len(commands), 0)
-        with patch(
-            "varats.experiment.workload_util.get_extra_config_options",
-            return_value=["--compress"]
-        ):
-            commands = wu.workload_commands(
-                project, binary, [wu.WorkloadCategory.EXAMPLE]
-            )
-            self.assertEqual(len(commands), 1)
+        self.assertEqual(len(commands), 1)
+        commands = wu.workload_commands(
+            project, binary, [wu.WorkloadCategory.MEDIUM]
+        )
+        self.assertEqual(len(commands), 1)
 
 
 class TestWorkloadFilenames(unittest.TestCase):

--- a/tests/experiment/test_workload_util.py
+++ b/tests/experiment/test_workload_util.py
@@ -1,5 +1,6 @@
 """Test VaRA workload utilities."""
 import unittest
+from copy import deepcopy
 from pathlib import Path
 from unittest.mock import patch
 
@@ -55,7 +56,7 @@ class TestWorkloadCommands(unittest.TestCase):
 
     def test_workload_commands_requires(self) -> None:
         revision = Revision(Xz, Variant(Xz.SOURCE[0], "c5c7ceb08a"))
-        project = Xz(revision=revision)
+        project = deepcopy(Xz(revision=revision))
         binary = Xz.binaries_for_revision(ShortCommitHash("c5c7ceb08a"))[0]
 
         commands = next(

--- a/varats-core/varats/experiment/workload_util.py
+++ b/varats-core/varats/experiment/workload_util.py
@@ -109,9 +109,7 @@ def workload_commands(
             prj_cmd.command, "requires_all"
         ) and prj_cmd.command.requires_all:
             args = set(prj_cmd.command._args).union(extra_options)
-            return prj_cmd.command.requires_all.issubset(
-                args
-            )  # type: ignore [no-any-return]
+            return bool(prj_cmd.command.requires_all.issubset(args))
         return True
 
     available_cmds = filter(

--- a/varats-core/varats/experiment/workload_util.py
+++ b/varats-core/varats/experiment/workload_util.py
@@ -109,7 +109,9 @@ def workload_commands(
             prj_cmd.command, "requires_all"
         ) and prj_cmd.command.requires_all:
             args = set(prj_cmd.command._args).union(extra_options)
-            return prj_cmd.command.requires_all.issubset(args)
+            return prj_cmd.command.requires_all.issubset(
+                args
+            )  # type: ignore [no-any-return]
         return True
 
     available_cmds = filter(

--- a/varats-core/varats/experiment/workload_util.py
+++ b/varats-core/varats/experiment/workload_util.py
@@ -94,11 +94,12 @@ def workload_commands(
     ]
 
     # Filter commands that have required args set.
-    options = set(get_extra_config_options(project))
+    extra_options = set(get_extra_config_options(project))
 
     def requires_filter(prj_cmd: ProjectCommand) -> bool:
         if hasattr(prj_cmd.command, "requires") and prj_cmd.command.requires:
-            return bool(options.intersection(prj_cmd.command.requires))
+            args = set(prj_cmd.command._args).union(extra_options)
+            return bool(args.intersection(prj_cmd.command.requires))
         return True
 
     available_cmds = filter(requires_filter, project_cmds)

--- a/varats-core/varats/experiment/workload_util.py
+++ b/varats-core/varats/experiment/workload_util.py
@@ -96,13 +96,25 @@ def workload_commands(
     # Filter commands that have required args set.
     extra_options = set(get_extra_config_options(project))
 
-    def requires_filter(prj_cmd: ProjectCommand) -> bool:
-        if hasattr(prj_cmd.command, "requires") and prj_cmd.command.requires:
+    def requires_any_filter(prj_cmd: ProjectCommand) -> bool:
+        if hasattr(
+            prj_cmd.command, "requires_any"
+        ) and prj_cmd.command.requires_any:
             args = set(prj_cmd.command._args).union(extra_options)
-            return bool(args.intersection(prj_cmd.command.requires))
+            return bool(args.intersection(prj_cmd.command.requires_any))
         return True
 
-    available_cmds = filter(requires_filter, project_cmds)
+    def requires_all_filter(prj_cmd: ProjectCommand) -> bool:
+        if hasattr(
+            prj_cmd.command, "requires_all"
+        ) and prj_cmd.command.requires_all:
+            args = set(prj_cmd.command._args).union(extra_options)
+            return prj_cmd.command.requires_all.issubset(args)
+        return True
+
+    available_cmds = filter(
+        requires_all_filter, filter(requires_any_filter, project_cmds)
+    )
 
     return list(
         filter(

--- a/varats-core/varats/experiment/workload_util.py
+++ b/varats-core/varats/experiment/workload_util.py
@@ -19,6 +19,7 @@ from benchbuild.command import (
     Command,
 )
 
+from varats.experiment.experiment_util import get_extra_config_options
 from varats.project.project_util import ProjectBinaryWrapper
 from varats.project.varats_project import VProject
 from varats.report.report import KeyedReportAggregate, ReportTy
@@ -92,8 +93,20 @@ def workload_commands(
         )
     ]
 
+    # Filter commands that have required args set.
+    options = set(get_extra_config_options(project))
+
+    def requires_filter(prj_cmd: ProjectCommand) -> bool:
+        if hasattr(prj_cmd.command, "requires") and prj_cmd.command.requires:
+            return bool(options.intersection(prj_cmd.command.requires))
+        return True
+
+    available_cmds = filter(requires_filter, project_cmds)
+
     return list(
-        filter(lambda prj_cmd: prj_cmd.path.name == binary.name, project_cmds)
+        filter(
+            lambda prj_cmd: prj_cmd.path.name == binary.name, available_cmds
+        )
     )
 
 

--- a/varats-core/varats/project/project_util.py
+++ b/varats-core/varats/project/project_util.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import benchbuild as bb
 import pygit2
-from benchbuild.command import Command as _Command
+from benchbuild.command import Command
 from benchbuild.source import Git
 from benchbuild.utils.cmd import git
 from plumbum import local
@@ -385,7 +385,7 @@ def copy_renamed_git_to_dest(src_dir: Path, dest_dir: Path) -> None:
                 os.rename(os.path.join(root, name), os.path.join(root, ".git"))
 
 
-class Command(_Command):  # type: ignore [misc]
+class WrappedCommand(Command):  # type: ignore [misc]
     """
     Wrapper around benchbuild's Command class.
 

--- a/varats-core/varats/project/project_util.py
+++ b/varats-core/varats/project/project_util.py
@@ -385,12 +385,13 @@ def copy_renamed_git_to_dest(src_dir: Path, dest_dir: Path) -> None:
                 os.rename(os.path.join(root, name), os.path.join(root, ".git"))
 
 
-class WrappedCommand(Command):  # type: ignore [misc]
+class VCommand(Command):  # type: ignore [misc]
     """
     Wrapper around benchbuild's Command class.
 
     Attributes:
-    requires: specify required args that must be added before execution.
+    requires_any: sufficient args that must be available for successful execution.
+    requires_all: all args that must be available for successful execution.
     """
 
     _requires: tp.Set[str]
@@ -398,13 +399,19 @@ class WrappedCommand(Command):  # type: ignore [misc]
     def __init__(
         self,
         *args: tp.Any,
-        requires: tp.Optional[tp.Set[str]] = None,
+        requires_any: tp.Optional[tp.Set[str]] = None,
+        requires_all: tp.Optional[tp.Set[str]] = None,
         **kwargs: tp.Union[str, tp.List[str]],
     ) -> None:
 
         super().__init__(*args, **kwargs)
-        self._requires = requires if requires else set()
+        self._requires_any = requires_any if requires_any else set()
+        self._requires_all = requires_all if requires_all else set()
 
     @property
-    def requires(self) -> tp.Set[str]:
-        return self._requires
+    def requires_any(self) -> tp.Set[str]:
+        return self._requires_any
+
+    @property
+    def requires_all(self) -> tp.Set[str]:
+        return self._requires_all

--- a/varats-core/varats/project/project_util.py
+++ b/varats-core/varats/project/project_util.py
@@ -385,7 +385,7 @@ def copy_renamed_git_to_dest(src_dir: Path, dest_dir: Path) -> None:
                 os.rename(os.path.join(root, name), os.path.join(root, ".git"))
 
 
-class Command(_Command):
+class Command(_Command):  # type: ignore [misc]
     """
     Wrapper around benchbuild's Command class.
 

--- a/varats-core/varats/project/project_util.py
+++ b/varats-core/varats/project/project_util.py
@@ -389,8 +389,8 @@ class Command(_Command):
     """
     Wrapper around benchbuild's Command class.
 
-    Additional functionality:     requires attribute:         specify required
-    args that must be added before execution.
+    Attributes:
+    requires: specify required args that must be added before execution.
     """
 
     _requires: tp.Set[str]

--- a/varats-core/varats/project/project_util.py
+++ b/varats-core/varats/project/project_util.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import benchbuild as bb
 import pygit2
+from benchbuild.command import Command as _Command
 from benchbuild.source import Git
 from benchbuild.utils.cmd import git
 from plumbum import local
@@ -382,3 +383,28 @@ def copy_renamed_git_to_dest(src_dir: Path, dest_dir: Path) -> None:
         for name in dirs:
             if name == ".gitted":
                 os.rename(os.path.join(root, name), os.path.join(root, ".git"))
+
+
+class Command(_Command):
+    """
+    Wrapper around benchbuild's Command class.
+
+    Additional functionality:     requires attribute:         specify required
+    args that must be added before execution.
+    """
+
+    _requires: tp.Set[str]
+
+    def __init__(
+        self,
+        *args: tp.Any,
+        requires: tp.Optional[tp.Set[str]] = None,
+        **kwargs: tp.Union[str, tp.List[str]],
+    ) -> None:
+
+        super().__init__(*args, **kwargs)
+        self._requires = requires if requires else set()
+
+    @property
+    def requires(self) -> tp.Set[str]:
+        return self._requires

--- a/varats/varats/projects/c_projects/xz.py
+++ b/varats/varats/projects/c_projects/xz.py
@@ -111,7 +111,6 @@ class Xz(VProject):
                 output=SourceRoot("geo-maps/countries-land-250m.geo.json"),
                 label="countries-land-250m",
                 creates=["geo-maps/countries-land-250m.geo.json.xz"],
-                requires_any={"--compress", "FooBar"},
                 requires_all={"--compress"},
             )
         ],

--- a/varats/varats/projects/c_projects/xz.py
+++ b/varats/varats/projects/c_projects/xz.py
@@ -2,7 +2,7 @@
 import typing as tp
 
 import benchbuild as bb
-from benchbuild.command import Command, SourceRoot, WorkloadSet
+from benchbuild.command import SourceRoot, WorkloadSet
 from benchbuild.source import HTTPMultiple
 from benchbuild.utils.cmd import autoreconf, make
 from benchbuild.utils.revision_ranges import (
@@ -18,6 +18,7 @@ from varats.experiment.workload_util import RSBinary, WorkloadCategory
 from varats.paper.paper_config import PaperConfigSpecificGit
 from varats.project.project_domain import ProjectDomains
 from varats.project.project_util import (
+    Command,
     ProjectBinaryWrapper,
     get_local_project_git_path,
     BinaryType,
@@ -87,7 +88,8 @@ class Xz(VProject):
             Command(
                 SourceRoot("xz") / RSBinary("xz"),
                 "-k",
-                "geo-maps/countries-land-1km.geo.json",
+                output_param=["{output}"],
+                output=SourceRoot("geo-maps/countries-land-250m.geo.json"),
                 label="countries-land-1km",
                 creates=["geo-maps/countries-land-1km.geo.json.xz"]
             )
@@ -101,7 +103,8 @@ class Xz(VProject):
                 "--threads=1",
                 "--format=xz",
                 "-vv",
-                "geo-maps/countries-land-250m.geo.json",
+                output_param=["{output}"],
+                output=SourceRoot("geo-maps/countries-land-250m.geo.json"),
                 label="countries-land-250m",
                 creates=["geo-maps/countries-land-250m.geo.json.xz"]
             )

--- a/varats/varats/projects/c_projects/xz.py
+++ b/varats/varats/projects/c_projects/xz.py
@@ -88,6 +88,8 @@ class Xz(VProject):
             VCommand(
                 SourceRoot("xz") / RSBinary("xz"),
                 "-k",
+                # Use output_param to ensure input file
+                # gets appended after all arguments.
                 output_param=["{output}"],
                 output=SourceRoot("geo-maps/countries-land-250m.geo.json"),
                 label="countries-land-1km",
@@ -103,6 +105,8 @@ class Xz(VProject):
                 "--threads=1",
                 "--format=xz",
                 "-vv",
+                # Use output_param to ensure input file
+                # gets appended after all arguments.
                 output_param=["{output}"],
                 output=SourceRoot("geo-maps/countries-land-250m.geo.json"),
                 label="countries-land-250m",

--- a/varats/varats/projects/c_projects/xz.py
+++ b/varats/varats/projects/c_projects/xz.py
@@ -18,7 +18,7 @@ from varats.experiment.workload_util import RSBinary, WorkloadCategory
 from varats.paper.paper_config import PaperConfigSpecificGit
 from varats.project.project_domain import ProjectDomains
 from varats.project.project_util import (
-    Command,
+    WrappedCommand,
     ProjectBinaryWrapper,
     get_local_project_git_path,
     BinaryType,
@@ -85,7 +85,7 @@ class Xz(VProject):
 
     WORKLOADS = {
         WorkloadSet(WorkloadCategory.EXAMPLE): [
-            Command(
+            WrappedCommand(
                 SourceRoot("xz") / RSBinary("xz"),
                 "-k",
                 output_param=["{output}"],
@@ -95,7 +95,7 @@ class Xz(VProject):
             )
         ],
         WorkloadSet(WorkloadCategory.MEDIUM): [
-            Command(
+            WrappedCommand(
                 SourceRoot("xz") / RSBinary("xz"),
                 "-k",
                 "-9e",
@@ -106,7 +106,8 @@ class Xz(VProject):
                 output_param=["{output}"],
                 output=SourceRoot("geo-maps/countries-land-250m.geo.json"),
                 label="countries-land-250m",
-                creates=["geo-maps/countries-land-250m.geo.json.xz"]
+                creates=["geo-maps/countries-land-250m.geo.json.xz"],
+                requires={"--compress"}
             )
         ],
     }

--- a/varats/varats/projects/c_projects/xz.py
+++ b/varats/varats/projects/c_projects/xz.py
@@ -18,7 +18,7 @@ from varats.experiment.workload_util import RSBinary, WorkloadCategory
 from varats.paper.paper_config import PaperConfigSpecificGit
 from varats.project.project_domain import ProjectDomains
 from varats.project.project_util import (
-    WrappedCommand,
+    VCommand,
     ProjectBinaryWrapper,
     get_local_project_git_path,
     BinaryType,
@@ -85,7 +85,7 @@ class Xz(VProject):
 
     WORKLOADS = {
         WorkloadSet(WorkloadCategory.EXAMPLE): [
-            WrappedCommand(
+            VCommand(
                 SourceRoot("xz") / RSBinary("xz"),
                 "-k",
                 output_param=["{output}"],
@@ -95,7 +95,7 @@ class Xz(VProject):
             )
         ],
         WorkloadSet(WorkloadCategory.MEDIUM): [
-            WrappedCommand(
+            VCommand(
                 SourceRoot("xz") / RSBinary("xz"),
                 "-k",
                 "-9e",
@@ -107,7 +107,8 @@ class Xz(VProject):
                 output=SourceRoot("geo-maps/countries-land-250m.geo.json"),
                 label="countries-land-250m",
                 creates=["geo-maps/countries-land-250m.geo.json.xz"],
-                requires={"--compress"}
+                requires_any={"--compress", "FooBar"},
+                requires_all={"--compress"},
             )
         ],
     }


### PR DESCRIPTION
The `requires` attribute is used by `workload_commands` to check if the command includes all necessary arguments.