### PR TITLE
Always load BB config from environment.

### DIFF
--- a/varats-core/varats/utils/settings.py
+++ b/varats-core/varats/utils/settings.py
@@ -283,7 +283,10 @@ def bb_cfg() -> s.Configuration:
             bb_cfg_path = Path(bb_root) / ".benchbuild.yml"
             if bb_cfg_path.exists():
                 BB_CFG.load(local.path(bb_cfg_path))
-                BB_CFG.init_from_env()
+
+        # Environment should always override config files
+        BB_CFG.init_from_env()
+
         _BB_CFG = BB_CFG
         create_missing_bb_folders()
     return _BB_CFG


### PR DESCRIPTION
Our load order for the BB config caused the "varats" block to always use default values if running benchbuild directly. This had the effect that container runs would write BC files to an incorrect directory that wasn't mounted from the outside. Therefore, BC files would never be cached when using containers.