### PR TITLE
Adds functionality for patch-based configuration

### DIFF
--- a/docs/source/tutorials/configuration_specific_experiments.rst
+++ b/docs/source/tutorials/configuration_specific_experiments.rst
@@ -21,6 +21,7 @@ One just needs to extend the case-study file of a project with a yaml document t
 .. code-block:: yaml
 
   ---
+  config_type: PlainCommandlineConfiguration
   0: '["--foo", "--bar"]'
   1: '["--foo"]'
   ...

--- a/tests/TEST_INPUTS/paper_configs/test_config_ids/SynthSAContextSensitivity_0.case_study
+++ b/tests/TEST_INPUTS/paper_configs/test_config_ids/SynthSAContextSensitivity_0.case_study
@@ -14,6 +14,7 @@ stages:
 version: 0
 ...
 ---
+config_type: PlainCommandlineConfiguration
 0: '["--compress", "--mem", "10", "8"]'
 1: '["--compress", "--mem", "300", "8"]'
 ...

--- a/tests/TEST_INPUTS/paper_configs/test_config_ids/xz_0.case_study
+++ b/tests/TEST_INPUTS/paper_configs/test_config_ids/xz_0.case_study
@@ -10,5 +10,6 @@ stages:
     config_ids: [1]
 version: 0
 ---
+config_type: PlainCommandlineConfiguration
 0: '["--foo", "--bar"]'
 1: '["--foo"]'

--- a/tests/paper/test_case_study.py
+++ b/tests/paper/test_case_study.py
@@ -48,6 +48,7 @@ stages:
     commit_id: 494
 ...
 ---
+config_type: ConfigurationImpl
 0: '{"foo": true, "bar": false, "bazz": "bazz-value", "buzz": "None"}'
 1: '{}'
 2: '{}'

--- a/tests/provider/test_patch_provider.py
+++ b/tests/provider/test_patch_provider.py
@@ -184,57 +184,120 @@ class TestPatchSet(unittest.TestCase):
                 "Test-ABCD",
                 "",
                 path=Path("test.patch"),
-                tags={"A", "B", "C", "D"}
-            ),
-            Patch("TEST", "Test-A", "", path=Path("test.patch"), tags={"A"}),
-            Patch("TEST", "Test-B", "", path=Path("test.patch"), tags={"B"}),
-            Patch("TEST", "Test-C", "", path=Path("test.patch"), tags={"C"}),
-            Patch("TEST", "Test-D", "", path=Path("test.patch"), tags={"D"}),
-            Patch(
-                "TEST", "Test-AB", "", path=Path("test.patch"), tags={"A", "B"}
+                tags={"A", "B", "C", "D"},
+                feature_tags={"F_A", "F_B", "F_C", "F_D"}
             ),
             Patch(
-                "TEST", "Test-AC", "", path=Path("test.patch"), tags={"A", "C"}
+                "TEST",
+                "Test-A",
+                "",
+                path=Path("test.patch"),
+                tags={"A"},
+                feature_tags={"F_A"}
             ),
             Patch(
-                "TEST", "Test-AD", "", path=Path("test.patch"), tags={"A", "D"}
+                "TEST",
+                "Test-B",
+                "",
+                path=Path("test.patch"),
+                tags={"B"},
+                feature_tags={"F_B"}
             ),
             Patch(
-                "TEST", "Test-BC", "", path=Path("test.patch"), tags={"B", "C"}
+                "TEST",
+                "Test-C",
+                "",
+                path=Path("test.patch"),
+                tags={"C"},
+                feature_tags={"F_C"}
             ),
             Patch(
-                "TEST", "Test-BD", "", path=Path("test.patch"), tags={"B", "D"}
+                "TEST",
+                "Test-D",
+                "",
+                path=Path("test.patch"),
+                tags={"D"},
+                feature_tags={"F_D"}
             ),
             Patch(
-                "TEST", "Test-CD", "", path=Path("test.patch"), tags={"C", "D"}
+                "TEST",
+                "Test-AB",
+                "",
+                path=Path("test.patch"),
+                tags={"A", "B"},
+                feature_tags={"F_A", "F_B"}
+            ),
+            Patch(
+                "TEST",
+                "Test-AC",
+                "",
+                path=Path("test.patch"),
+                tags={"A", "C"},
+                feature_tags={"F_A", "F_C"}
+            ),
+            Patch(
+                "TEST",
+                "Test-AD",
+                "",
+                path=Path("test.patch"),
+                tags={"A", "D"},
+                feature_tags={"F_A", "F_D"}
+            ),
+            Patch(
+                "TEST",
+                "Test-BC",
+                "",
+                path=Path("test.patch"),
+                tags={"B", "C"},
+                feature_tags={"F_B", "F_C"}
+            ),
+            Patch(
+                "TEST",
+                "Test-BD",
+                "",
+                path=Path("test.patch"),
+                tags={"B", "D"},
+                feature_tags={"F_B", "F_D"}
+            ),
+            Patch(
+                "TEST",
+                "Test-CD",
+                "",
+                path=Path("test.patch"),
+                tags={"C", "D"},
+                feature_tags={"F_C", "F_D"}
             ),
             Patch(
                 "TEST",
                 "Test-ABC",
                 "",
                 path=Path("test.patch"),
-                tags={"A", "B", "C"}
+                tags={"A", "B", "C"},
+                feature_tags={"F_A", "F_B", "F_C"}
             ),
             Patch(
                 "TEST",
                 "Test-ABD",
                 "",
                 path=Path("test.patch"),
-                tags={"A", "B", "D"}
+                tags={"A", "B", "D"},
+                feature_tags={"F_A", "F_B", "F_D"}
             ),
             Patch(
                 "TEST",
                 "Test-ACD",
                 "",
                 path=Path("test.patch"),
-                tags={"A", "C", "D"}
+                tags={"A", "C", "D"},
+                feature_tags={"F_A", "F_C", "F_D"}
             ),
             Patch(
                 "TEST",
                 "Test-BCD",
                 "",
                 path=Path("test.patch"),
-                tags={"B", "C", "D"}
+                tags={"B", "C", "D"},
+                feature_tags={"F_B", "F_C", "F_D"}
             ),
         }
 
@@ -310,6 +373,38 @@ class TestPatchSet(unittest.TestCase):
 
             for patch in patches:
                 any([tag in patch.tags for tag in tags])
+
+    def test_all_of_single_feature_tag(self):
+        for tag in {"F_A", "F_B", "F_C", "F_D"}:
+            patches = self.patchSet.all_of_features([tag])
+            self.assertEqual(8, len(patches))
+
+    def test_all_of_multiple_feature_tags(self):
+        tags_count = {("F_A", "F_B"): 4,
+                      ("F_C", "F_B"): 4,
+                      ("F_D", "F_B"): 4,
+                      ("F_A", "F_B", "F_C"): 2,
+                      ("F_A", "F_B", "F_C", "F_D"): 1}
+
+        for tags in tags_count:
+            patches = self.patchSet.all_of_features(tags)
+            self.assertEqual(tags_count[tags], len(patches))
+
+    def test_any_of_single_feature_tag(self):
+        for tag in {"F_A", "F_B", "F_C", "F_D"}:
+            patches = self.patchSet.any_of_features([tag])
+            self.assertEqual(8, len(patches))
+
+    def test_any_of_multiple_feature_tags(self):
+        tags_count = {("F_A", "F_B"): 12,
+                      ("F_C", "F_B"): 12,
+                      ("F_D", "F_B"): 12,
+                      ("F_A", "F_B", "F_C"): 14,
+                      ("F_A", "F_B", "F_C", "F_D"): 15}
+
+        for tags in tags_count:
+            patches = self.patchSet.any_of_features(tags)
+            self.assertEqual(tags_count[tags], len(patches))
 
     def test_patchset_intersection(self):
         patches = self.patchSet["A"] & self.patchSet["B"]

--- a/varats-core/varats/base/configuration.py
+++ b/varats-core/varats/base/configuration.py
@@ -441,12 +441,11 @@ class PatchConfiguration(Configuration):
         self.add_config_option(ConfigurationOptionImpl(option_name, value))
 
     def get_config_value(self, option_name: str) -> tp.Optional[tp.Any]:
-        return any(
-            filter(
-                lambda option: option.name == option_name,
-                self.__patch_feature_tags
-            )
+        filtered_options = filter(
+            lambda option: (option.name == option_name),
+            self.__patch_feature_tags
         )
+        return any(filtered_options)
 
     def options(self) -> tp.List[ConfigurationOption]:
         return list(self.__patch_feature_tags)

--- a/varats-core/varats/base/configuration.py
+++ b/varats-core/varats/base/configuration.py
@@ -414,3 +414,50 @@ class PlainCommandlineConfiguration(Configuration):
 
     def unfreeze(self) -> Configuration:
         return self
+
+
+class PatchConfiguration(Configuration):
+    """Configuration class for projects where configuring is done by applying a
+    patch."""
+
+    def __init__(self, patch_feature_tags: tp.Set[str]):
+        self.__patch_feature_tags: tp.Set[ConfigurationOption] = {
+            ConfigurationOptionImpl(tag, tag) for tag in patch_feature_tags
+        }
+
+    @staticmethod
+    def create_configuration_from_str(config_str: str) -> Configuration:
+        patch_feature_tags = json.loads(config_str)
+        return PatchConfiguration(patch_feature_tags)
+
+    def add_config_option(self, option: ConfigurationOption) -> None:
+        self.__patch_feature_tags.add(option)
+
+    def set_config_option(self, option_name: str, value: tp.Any) -> None:
+        self.__patch_feature_tags = {
+            option for option in self.__patch_feature_tags
+            if option.name != option_name
+        }
+        self.add_config_option(ConfigurationOptionImpl(option_name, value))
+
+    def get_config_value(self, option_name: str) -> tp.Optional[tp.Any]:
+        return any(
+            filter(
+                lambda option: option.name == option_name,
+                self.__patch_feature_tags
+            )
+        )
+
+    def options(self) -> tp.List[ConfigurationOption]:
+        return list(self.__patch_feature_tags)
+
+    def dump_to_string(self) -> str:
+        return ", ".join(
+            map(lambda option: str(option.value), self.__patch_feature_tags)
+        )
+
+    def freeze(self) -> FrozenConfiguration:
+        return FrozenConfiguration(deepcopy(self))
+
+    def unfreeze(self) -> Configuration:
+        return self

--- a/varats-core/varats/experiment/experiment_util.py
+++ b/varats-core/varats/experiment/experiment_util.py
@@ -27,6 +27,7 @@ from varats.base.configuration import (
     PatchConfiguration,
     Configuration,
 )
+from varats.experiment.steps.patch import ApplyPatch
 from varats.paper.paper_config import get_paper_config
 from varats.project.project_util import ProjectBinaryWrapper
 from varats.project.sources import FeatureSource
@@ -770,3 +771,21 @@ def get_config_patches(project: VProject) -> PatchSet:
     )
 
     return patches
+
+
+def get_config_patch_steps(project: VProject) -> tp.MutableSequence[Step]:
+    """
+    Get a list of actions that apply all configuration patches to the project.
+
+    Args:
+        project: the project to be configured
+
+    Returns:
+        the actions that configure the project
+    """
+    return list(
+        map(
+            lambda patch: ApplyPatch(project, patch),
+            get_config_patches(project)
+        )
+    )

--- a/varats-core/varats/experiment/experiment_util.py
+++ b/varats-core/varats/experiment/experiment_util.py
@@ -724,11 +724,6 @@ def get_config(
 
     config = config_map.get_configuration(config_id)
 
-    if config is None:
-        raise AssertionError(
-            "Requested config id was not in the map, but should be"
-        )
-
     return config
 
 

--- a/varats-core/varats/experiment/workload_util.py
+++ b/varats-core/varats/experiment/workload_util.py
@@ -23,7 +23,8 @@ from varats.experiment.experiment_util import (
     get_extra_config_options,
     get_config_patches,
 )
-from varats.project.project_util import ProjectBinaryWrapper, VCommand
+from varats.project.project_util import ProjectBinaryWrapper
+from varats.project.varats_command import VCommand
 from varats.project.varats_project import VProject
 from varats.report.report import KeyedReportAggregate, ReportTy
 from varats.utils.exceptions import auto_unwrap

--- a/varats-core/varats/experiment/workload_util.py
+++ b/varats-core/varats/experiment/workload_util.py
@@ -19,7 +19,10 @@ from benchbuild.command import (
     Command,
 )
 
-from varats.experiment.experiment_util import get_extra_config_options
+from varats.experiment.experiment_util import (
+    get_extra_config_options,
+    get_config_patches,
+)
 from varats.project.project_util import ProjectBinaryWrapper, VCommand
 from varats.project.varats_project import VProject
 from varats.report.report import KeyedReportAggregate, ReportTy
@@ -93,13 +96,13 @@ def workload_commands(
         )
     ]
 
-    # Filter commands that have required args set.
+    # Filter commands that have required args and patches set.
     extra_options = set(get_extra_config_options(project))
+    patches = get_config_patches(project)
 
     def filter_by_config(prj_cmd: ProjectCommand) -> bool:
-        # TODO: pass applied patches
         if isinstance(prj_cmd.command, VCommand):
-            return prj_cmd.command.can_be_executed_by(extra_options, set())
+            return prj_cmd.command.can_be_executed_by(extra_options, patches)
         return True
 
     return [

--- a/varats-core/varats/mapping/configuration_map.py
+++ b/varats-core/varats/mapping/configuration_map.py
@@ -141,6 +141,7 @@ def create_configuration_map_from_yaml_doc(
     """
 
     new_config_map = ConfigurationMap()
+    yaml_doc.pop("config_type", None)
 
     for config_id in sorted(yaml_doc):
         parsed_config = concrete_config_type.create_configuration_from_str(

--- a/varats-core/varats/paper/case_study.py
+++ b/varats-core/varats/paper/case_study.py
@@ -581,17 +581,18 @@ def load_configuration_map_from_case_study_file(
     version_header.raise_if_version_is_less_than(1)
 
     next(documents)  # skip case study document
-    while True:
-        document = next(documents)
-        if not document:
-            raise AssertionError("Configuration missing from case study file.")
+    try:
+        while True:
+            document = next(documents)
 
-        if document["config_type"] == concrete_config_type.__name__:
-            break
+            if document["config_type"] == concrete_config_type.__name__:
+                break
 
-    return create_configuration_map_from_yaml_doc(
-        document, concrete_config_type
-    )
+        return create_configuration_map_from_yaml_doc(
+            document, concrete_config_type
+        )
+    except StopIteration:
+        return ConfigurationMap()
 
 
 def store_case_study(case_study: CaseStudy, case_study_location: Path) -> None:

--- a/varats-core/varats/paper/case_study.py
+++ b/varats-core/varats/paper/case_study.py
@@ -6,7 +6,11 @@ from pathlib import Path
 
 import benchbuild as bb
 
-from varats.base.configuration import Configuration
+from varats.base.configuration import (
+    Configuration,
+    PlainCommandlineConfiguration,
+    PatchConfiguration,
+)
 from varats.base.sampling_method import (
     NormalSamplingMethod,
     SamplingMethodBase,
@@ -213,6 +217,11 @@ class CaseStudy():
      - name of the related benchbuild.project
      - a set of revisions
     """
+
+    CONFIG_FILE_INDICES: tp.Dict[tp.Type[Configuration], int] = {
+        PlainCommandlineConfiguration: 1,
+        PatchConfiguration: 2
+    }
 
     def __init__(
         self,
@@ -580,7 +589,9 @@ def load_configuration_map_from_case_study_file(
     version_header.raise_if_not_type("CaseStudy")
     version_header.raise_if_version_is_less_than(1)
 
-    next(documents)  # Skip case study yaml-doc
+    config_index = CaseStudy.CONFIG_FILE_INDICES[concrete_config_type]
+    for _ in range(config_index):
+        next(documents)
 
     return create_configuration_map_from_yaml_doc(
         next(documents), concrete_config_type

--- a/varats-core/varats/paper/case_study.py
+++ b/varats-core/varats/paper/case_study.py
@@ -6,11 +6,7 @@ from pathlib import Path
 
 import benchbuild as bb
 
-from varats.base.configuration import (
-    Configuration,
-    PlainCommandlineConfiguration,
-    PatchConfiguration,
-)
+from varats.base.configuration import Configuration
 from varats.base.sampling_method import (
     NormalSamplingMethod,
     SamplingMethodBase,
@@ -173,7 +169,7 @@ class CSStage():
         Returns a list of all configuration IDs specified for this revision.
 
         Args:
-            revision: i.e., a commit hash registed in this ``CSStage``
+            revision: i.e., a commit hash registered in this ``CSStage``
 
         Returns: list of config IDs
         """
@@ -217,11 +213,6 @@ class CaseStudy():
      - name of the related benchbuild.project
      - a set of revisions
     """
-
-    CONFIG_FILE_INDICES: tp.Dict[tp.Type[Configuration], int] = {
-        PlainCommandlineConfiguration: 1,
-        PatchConfiguration: 2
-    }
 
     def __init__(
         self,
@@ -589,12 +580,17 @@ def load_configuration_map_from_case_study_file(
     version_header.raise_if_not_type("CaseStudy")
     version_header.raise_if_version_is_less_than(1)
 
-    config_index = CaseStudy.CONFIG_FILE_INDICES[concrete_config_type]
-    for _ in range(config_index):
-        next(documents)
+    next(documents)  # skip case study document
+    while True:
+        document = next(documents)
+        if not document:
+            raise AssertionError("Configuration missing from case study file.")
+
+        if document["config_type"] == concrete_config_type.__name__:
+            break
 
     return create_configuration_map_from_yaml_doc(
-        next(documents), concrete_config_type
+        document, concrete_config_type
     )
 
 

--- a/varats-core/varats/project/project_util.py
+++ b/varats-core/varats/project/project_util.py
@@ -16,7 +16,7 @@ from plumbum.commands.base import BoundCommand
 from varats.utils.settings import bb_cfg
 
 if tp.TYPE_CHECKING:
-    from varats.provider.patch.patch_provider import Patch
+    from varats.provider.patch.patch_provider import Patch, PatchSet
 
 LOG = logging.getLogger(__name__)
 
@@ -438,11 +438,24 @@ class VCommand(Command):  # type: ignore [misc]
         return self._requires_all_patch
 
     def can_be_executed_by(
-        self, extra_args: tp.Set[str], applied_patches: tp.Set['Patch']
+        self, extra_args: tp.Set[str], applied_patches: 'PatchSet'
     ) -> bool:
+        """
+        Checks whether this command can be executed with the give configuration.
+
+        Args:
+            extra_args: additional command line arguments that will be passed to
+                        the command
+            applied_patches: patches that were applied to create the executable
+
+        Returns:
+            whether this command can be executed
+        """
         all_args = set(self._args).union(extra_args)
-        # TODO: extract tags from patches
-        all_patch_tags = {"" for patch in applied_patches}
+        all_patch_tags: tp.Set[str] = set()
+        for patch in applied_patches:
+            if patch.feature_tags:
+                all_patch_tags.update(patch.feature_tags)
 
         return bool((
             not self.requires_any_args or

--- a/varats-core/varats/project/project_util.py
+++ b/varats-core/varats/project/project_util.py
@@ -7,16 +7,12 @@ from pathlib import Path
 
 import benchbuild as bb
 import pygit2
-from benchbuild.command import Command
 from benchbuild.source import Git
 from benchbuild.utils.cmd import git
 from plumbum import local
 from plumbum.commands.base import BoundCommand
 
 from varats.utils.settings import bb_cfg
-
-if tp.TYPE_CHECKING:
-    from varats.provider.patch.patch_provider import Patch, PatchSet
 
 LOG = logging.getLogger(__name__)
 
@@ -386,87 +382,3 @@ def copy_renamed_git_to_dest(src_dir: Path, dest_dir: Path) -> None:
         for name in dirs:
             if name == ".gitted":
                 os.rename(os.path.join(root, name), os.path.join(root, ".git"))
-
-
-class VCommand(Command):  # type: ignore [misc]
-    """
-    Wrapper around benchbuild's Command class.
-
-    Attributes:
-    requires_any_args: any of these command line args must be available for
-                       successful execution.
-    requires_all_args: all of these command line args must be available for
-                       successful execution.
-    requires_any_patch: any of these patch feature-tags must be available for
-                       successful execution.
-    requires_all_patch: all of these patch feature-tags must be available for
-                       successful execution.
-    """
-
-    _requires: tp.Set[str]
-
-    def __init__(
-        self,
-        *args: tp.Any,
-        requires_any_args: tp.Optional[tp.Set[str]] = None,
-        requires_all_args: tp.Optional[tp.Set[str]] = None,
-        requires_any_patch: tp.Optional[tp.Set[str]] = None,
-        requires_all_patch: tp.Optional[tp.Set[str]] = None,
-        **kwargs: tp.Union[str, tp.List[str]],
-    ) -> None:
-
-        super().__init__(*args, **kwargs)
-        self._requires_any_args = requires_any_args or set()
-        self._requires_all_args = requires_all_args or set()
-        self._requires_any_patch = requires_any_patch or set()
-        self._requires_all_patch = requires_all_patch or set()
-
-    @property
-    def requires_any_args(self) -> tp.Set[str]:
-        return self._requires_any_args
-
-    @property
-    def requires_all_args(self) -> tp.Set[str]:
-        return self._requires_all_args
-
-    @property
-    def requires_any_patch(self) -> tp.Set[str]:
-        return self._requires_any_patch
-
-    @property
-    def requires_all_patch(self) -> tp.Set[str]:
-        return self._requires_all_patch
-
-    def can_be_executed_by(
-        self, extra_args: tp.Set[str], applied_patches: 'PatchSet'
-    ) -> bool:
-        """
-        Checks whether this command can be executed with the give configuration.
-
-        Args:
-            extra_args: additional command line arguments that will be passed to
-                        the command
-            applied_patches: patches that were applied to create the executable
-
-        Returns:
-            whether this command can be executed
-        """
-        all_args = set(self._args).union(extra_args)
-        all_patch_tags: tp.Set[str] = set()
-        for patch in applied_patches:
-            if patch.feature_tags:
-                all_patch_tags.update(patch.feature_tags)
-
-        return bool((
-            not self.requires_any_args or
-            all_args.intersection(self.requires_any_args)
-        ) and (
-            not self.requires_all_args or
-            self.requires_all_args.issubset(all_args)
-        ) and (
-            not self.requires_any_patch or
-            all_patch_tags.intersection(self.requires_any_patch)
-        ) and (
-            not self.requires_all_patch or
-            self.requires_all_patch.issubset(all_patch_tags)
-        ))

--- a/varats-core/varats/project/varats_command.py
+++ b/varats-core/varats/project/varats_command.py
@@ -1,0 +1,92 @@
+"""Custom version of benchbuild's Command for use with the VaRA-Tool-Suite."""
+import typing as tp
+
+from benchbuild.command import Command
+
+if tp.TYPE_CHECKING:
+    import varats.provider.patch.patch_provider as patch_provider
+
+
+class VCommand(Command):  # type: ignore [misc]
+    """
+    Wrapper around benchbuild's Command class.
+
+    Attributes:
+    requires_any_args: any of these command line args must be available for
+                       successful execution.
+    requires_all_args: all of these command line args must be available for
+                       successful execution.
+    requires_any_patch: any of these patch feature-tags must be available for
+                       successful execution.
+    requires_all_patch: all of these patch feature-tags must be available for
+                       successful execution.
+    """
+
+    _requires: tp.Set[str]
+
+    def __init__(
+        self,
+        *args: tp.Any,
+        requires_any_args: tp.Optional[tp.Set[str]] = None,
+        requires_all_args: tp.Optional[tp.Set[str]] = None,
+        requires_any_patch: tp.Optional[tp.Set[str]] = None,
+        requires_all_patch: tp.Optional[tp.Set[str]] = None,
+        **kwargs: tp.Union[str, tp.List[str]],
+    ) -> None:
+
+        super().__init__(*args, **kwargs)
+        self._requires_any_args = requires_any_args or set()
+        self._requires_all_args = requires_all_args or set()
+        self._requires_any_patch = requires_any_patch or set()
+        self._requires_all_patch = requires_all_patch or set()
+
+    @property
+    def requires_any_args(self) -> tp.Set[str]:
+        return self._requires_any_args
+
+    @property
+    def requires_all_args(self) -> tp.Set[str]:
+        return self._requires_all_args
+
+    @property
+    def requires_any_patch(self) -> tp.Set[str]:
+        return self._requires_any_patch
+
+    @property
+    def requires_all_patch(self) -> tp.Set[str]:
+        return self._requires_all_patch
+
+    def can_be_executed_by(
+        self, extra_args: tp.Set[str],
+        applied_patches: 'patch_provider.PatchSet'
+    ) -> bool:
+        """
+        Checks whether this command can be executed with the give configuration.
+
+        Args:
+            extra_args: additional command line arguments that will be passed to
+                        the command
+            applied_patches: patches that were applied to create the executable
+
+        Returns:
+            whether this command can be executed
+        """
+        all_args = set(self._args).union(extra_args)
+        all_patch_tags: tp.Set[str] = set()
+        for patch in applied_patches:
+            if patch.feature_tags:
+                all_patch_tags.update(patch.feature_tags)
+
+        return bool((
+            not self.requires_any_args or
+            all_args.intersection(self.requires_any_args)
+        ) and (
+            not self.requires_all_args or
+            self.requires_all_args.issubset(all_args)
+        ) and (
+            not self.requires_any_patch or
+            all_patch_tags.intersection(self.requires_any_patch)
+        ) and (
+            not self.requires_all_patch or
+            self.requires_all_patch.issubset(all_patch_tags)
+        ))

--- a/varats-core/varats/utils/filesystem_util.py
+++ b/varats-core/varats/utils/filesystem_util.py
@@ -18,7 +18,8 @@ class FolderAlreadyPresentError(Exception):
 
 
 @contextmanager
-def lock_file(lock_path: Path, lock_mode: int = fcntl.LOCK_EX) -> tp.Generator:
+def lock_file(lock_path: Path,
+              lock_mode: int = fcntl.LOCK_EX) -> tp.Generator[None, None, None]:
     open_mode = os.O_RDWR | os.O_CREAT | os.O_TRUNC
     lock_fd = os.open(lock_path, open_mode)
     try:

--- a/varats/varats/projects/c_projects/xz.py
+++ b/varats/varats/projects/c_projects/xz.py
@@ -111,7 +111,7 @@ class Xz(VProject):
                 output=SourceRoot("geo-maps/countries-land-250m.geo.json"),
                 label="countries-land-250m",
                 creates=["geo-maps/countries-land-250m.geo.json.xz"],
-                requires_all={"--compress"},
+                requires_all_args={"--compress"},
             )
         ],
     }

--- a/varats/varats/projects/c_projects/xz.py
+++ b/varats/varats/projects/c_projects/xz.py
@@ -18,13 +18,13 @@ from varats.experiment.workload_util import RSBinary, WorkloadCategory
 from varats.paper.paper_config import PaperConfigSpecificGit
 from varats.project.project_domain import ProjectDomains
 from varats.project.project_util import (
-    VCommand,
     ProjectBinaryWrapper,
     get_local_project_git_path,
     BinaryType,
     verify_binaries,
 )
 from varats.project.sources import FeatureSource
+from varats.project.varats_command import VCommand
 from varats.project.varats_project import VProject
 from varats.utils.git_util import (
     ShortCommitHash,


### PR DESCRIPTION
Compile-time configurable projects can now be configured using patches.
Therefore, patches can specify a list of `feature_tags`.

Case studies can contain a configuration map with `PatchConfiguration`s that contains a mapping from config id to a list of feature tags associated with this configuration.

Configuration patches are selected by matching their feature tags to the feature tags of the given configuration.

Since there are multiple types of configuration maps now, their type must be specified using the key `config_type` in case study files.