### PR TITLE
Simplify BlackBox Experiments for FeaturePerfPrecision

### DIFF
--- a/varats/varats/data/databases/feature_perf_precision_database.py
+++ b/varats/varats/data/databases/feature_perf_precision_database.py
@@ -427,7 +427,7 @@ class EbpfTraceTEF(Profiler):
     def __init__(self) -> None:
         super().__init__(
             "eBPFTrace", fpp.EbpfTraceTEFProfileRunner,
-            fpp.TEFProfileOverheadRunner, fpp.MPRTEFAggregate
+            fpp.EbpfTraceTEFOverheadRunner, fpp.MPRTEFAggregate
         )
 
     def is_regression(


### PR DESCRIPTION
The current implementations of the black box experiments for the feature perf precision experiments are basically equivalent to the `setup_actions_for_vara_experiment`/`setup_actions_for_vara_overhead_experiment` methods.

With some minor changes we can avoid this code duplication