### PR TITLE
Fix .isort.cfg

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,5 +1,6 @@
 [settings]
-known_firstparty = varats
+known_first_party = varats
+known_third_party = benchbuild
 multi_line_output=3
 use_parentheses = True
 include_trailing_comma: True


### PR DESCRIPTION
This fixes the `known_first_party` key and adds benchbuild as a known third party. In some local setups (mine) this seems to be required as otherwise isort sorts imports incorrectly on the pre-commit hook. (In my case, specifically and only `import benchbuild as bb` always gets put in a wrong position)