### PR TITLE
- Fix usages of typed_revision_range

### DIFF
--- a/varats/varats/projects/c_projects/bzip2.py
+++ b/varats/varats/projects/c_projects/bzip2.py
@@ -24,7 +24,11 @@ from varats.project.project_util import (
 from varats.project.sources import FeatureSource
 from varats.project.varats_command import VCommand
 from varats.project.varats_project import VProject
-from varats.utils.git_util import ShortCommitHash, typed_revision_range
+from varats.utils.git_util import (
+    ShortCommitHash,
+    typed_revision_range,
+    RepositoryHandle,
+)
 from varats.utils.settings import bb_cfg
 
 
@@ -160,17 +164,18 @@ class Bzip2(VProject):
         """Compile the project."""
         bzip2_source = Path(self.source_of_primary)
         bzip2_version = ShortCommitHash(self.version_of_primary)
+        bzip2_repo = RepositoryHandle(bzip2_source)
         cc_compiler = bb.compiler.cc(self)
         cxx_compiler = bb.compiler.cxx(self)
 
         if bzip2_version in typed_revision_range(
-            Bzip2._MAKE_VERSIONS, bzip2_source, ShortCommitHash
+            bzip2_repo, Bzip2._MAKE_VERSIONS, ShortCommitHash
         ):
             with local.cwd(bzip2_source):
                 with local.env(CC=str(cc_compiler)):
                     bb.watch(make)("-j", get_number_of_jobs(bb_cfg()))
         elif bzip2_version in typed_revision_range(
-            Bzip2._AUTOTOOLS_VERSIONS, bzip2_source, ShortCommitHash
+            bzip2_repo, Bzip2._AUTOTOOLS_VERSIONS, ShortCommitHash
         ):
             with local.cwd(bzip2_source):
                 with local.env(CC=str(cc_compiler)):
@@ -195,11 +200,12 @@ class Bzip2(VProject):
         """Recompile the project."""
         bzip2_source = Path(self.source_of_primary)
         bzip2_version = ShortCommitHash(self.version_of_primary)
+        bzip2_repo = RepositoryHandle(bzip2_source)
 
         if bzip2_version in typed_revision_range(
-            Bzip2._MAKE_VERSIONS, bzip2_source, ShortCommitHash
+            bzip2_repo, Bzip2._MAKE_VERSIONS, ShortCommitHash
         ) or bzip2_version in typed_revision_range(
-            Bzip2._AUTOTOOLS_VERSIONS, bzip2_source, ShortCommitHash
+            bzip2_repo, Bzip2._AUTOTOOLS_VERSIONS, ShortCommitHash
         ):
             with local.cwd(bzip2_source / "build"):
                 bb.watch(make)("-j", get_number_of_jobs(bb_cfg()))

--- a/varats/varats/projects/c_projects/htop.py
+++ b/varats/varats/projects/c_projects/htop.py
@@ -19,7 +19,11 @@ from varats.project.project_util import (
     RevisionBinaryMap,
 )
 from varats.project.varats_project import VProject
-from varats.utils.git_util import ShortCommitHash, typed_revision_range
+from varats.utils.git_util import (
+    ShortCommitHash,
+    typed_revision_range,
+    RepositoryHandle,
+)
 from varats.utils.settings import bb_cfg
 
 
@@ -62,7 +66,7 @@ class Htop(VProject):
     def compile(self) -> None:
         """Compile the project."""
         htop_source = local.path(self.source_of_primary)
-        htop_version_source = Path(self.source_of_primary)
+        htop_version_repo = RepositoryHandle(Path(self.source_of_primary))
         htop_version = ShortCommitHash(self.version_of_primary)
 
         configure_flags: tp.List[str] = []
@@ -72,7 +76,7 @@ class Htop(VProject):
                                    ["dfd9279f87791e36a5212726781c31fbe7110361"],
                                    "Needs CFLAGS=-fcommon")
         if htop_version in typed_revision_range(
-            old_revs, htop_version_source, ShortCommitHash
+            htop_version_repo, old_revs, ShortCommitHash
         ):
             configure_flags += ["CFLAGS=-fcommon"]
 


### PR DESCRIPTION
This fixes calls to `typed_revision_ranges` that were missed during the `RepositoryHandle` (#890)  refactoring.