### PR TITLE
Change helper function names starting with "test"

### DIFF
--- a/tests/data/test_commit_report.py
+++ b/tests/data/test_commit_report.py
@@ -351,7 +351,7 @@ class TestCommitReport(unittest.TestCase):
         )
 
 
-def testing_gen_commit_map() -> CommitMap:
+def _testing_gen_commit_map() -> CommitMap:
     """Generate a local commit map for testing."""
 
     initialize_projects()
@@ -372,7 +372,7 @@ class TestCommitMap(unittest.TestCase):
     def setUpClass(cls) -> None:
         """Setup file and CommitReport."""
 
-        cls.cmap = testing_gen_commit_map()
+        cls.cmap = _testing_gen_commit_map()
 
     def test_time_id(self) -> None:
         """Test time id look up."""
@@ -451,7 +451,7 @@ class MockCommitMap(CommitMap):
             self._hash_to_id_master[slices[1]] = int(slices[0])
 
 
-def testing_gen_mock_commit_map() -> CommitMap:
+def _testing_gen_mock_commit_map() -> CommitMap:
     """Generate a local commit map from a mock log for testing."""
 
     def commit_log_stream() -> tp.Generator[str, None, None]:
@@ -476,7 +476,7 @@ class TestCommitConnectionGenerators(unittest.TestCase):
         ):
             cls.commit_report = CommitReport(Path("fake_file_path"))
 
-        cls.cmap = testing_gen_mock_commit_map()
+        cls.cmap = _testing_gen_mock_commit_map()
 
     def test_gen_interactions_nodes(self) -> None:
         """Test generation of interaction node."""

--- a/tests/helper_utils.py
+++ b/tests/helper_utils.py
@@ -241,7 +241,9 @@ def run_in_test_environment(
     return wrapper_func
 
 
-def test_environment(*required_test_inputs: UnitTestFixture) -> TestEnvironment:
+def create_test_environment(
+    *required_test_inputs: UnitTestFixture
+) -> TestEnvironment:
     """
     Context manager that creates an isolated test environment.
 

--- a/tests/utils/test_cli_util.py
+++ b/tests/utils/test_cli_util.py
@@ -5,7 +5,7 @@ import unittest.mock as mock
 from enum import Enum
 from pathlib import Path
 
-from tests.helper_utils import run_in_test_environment, test_environment
+from tests.helper_utils import run_in_test_environment, create_test_environment
 from varats.tools.research_tools.phasar import Phasar
 from varats.tools.research_tools.vara import VaRA
 from varats.tools.tool_util import get_research_tool_type, get_research_tool
@@ -29,7 +29,7 @@ class ResearchToolUtils(unittest.TestCase):
     def test_research_tool_accessor_default(self, _):
         """Checks if the source_location of a ``ResearchTool`` is set to the
         correct default."""
-        with test_environment() as tmp_path:
+        with create_test_environment() as tmp_path:
             vara_cfg()["config_file"] = tmp_path / "dummy.yml"
             vara_cfg()["vara"]["llvm_source_dir"] = tmp_path / "tools_src"
             vara = get_research_tool("vara")


### PR DESCRIPTION
pytest mistakenly collects these functions and assumes they are tests, which causes our pipelines to fail.