### PR TITLE
Add a fetch interval to the Patch Provider

### DIFF
--- a/varats-core/varats/provider/patch/patch_provider.py
+++ b/varats-core/varats/provider/patch/patch_provider.py
@@ -282,10 +282,11 @@ class PatchProvider(Provider):
         shallow=False
     )
 
-    def __init__(self, project: tp.Type[Project]):
+    def __init__(self, project: tp.Type[Project], fetch_interval: int = 3600):
         super().__init__(project)
+        self.__fetch_interval = fetch_interval
 
-        self._update_local_patches_repo()
+        self._update_local_patches_repo(fetch_interval)
         repo = self._get_patches_repository()
 
         patches_project_dir = repo.worktree_path / self.project.NAME
@@ -300,7 +301,9 @@ class PatchProvider(Provider):
 
         # Update repository to have all upstream changes
         project_repo = get_local_project_repo(self.project.NAME)
-        fetch_repository(project_repo)
+
+        if project_repo.last_fetch >= self.__fetch_interval:
+            fetch_repository(project_repo)
 
         for root, _, files in os.walk(patches_project_dir):
             for filename in files:
@@ -336,7 +339,8 @@ class PatchProvider(Provider):
 
     @classmethod
     def create_provider_for_project(
-        cls: tp.Type[ProviderType], project: tp.Type[Project]
+        cls: tp.Type[ProviderType], project: tp.Type[Project],
+        fetch_interval: int
     ) -> 'PatchProvider':
         """
         Creates a provider instance for the given project.
@@ -348,7 +352,7 @@ class PatchProvider(Provider):
         Returns:
             a provider instance for the given project
         """
-        return PatchProvider(project)
+        return PatchProvider(project, fetch_interval)
 
     @classmethod
     def create_default_provider(
@@ -370,10 +374,11 @@ class PatchProvider(Provider):
             Path(target_prefix()) / cls.patches_source.local
         )
 
-    @classmethod
-    def _update_local_patches_repo(cls) -> None:
+    def _update_local_patches_repo(self) -> None:
         lock_path = Path(target_prefix()) / "patch_provider.lock"
 
         with lock_file(lock_path):
-            cls.patches_source.fetch()
-            pull_current_branch(cls._get_patches_repository())
+            patches_repo = self._get_patches_repository()
+            if patches_repo.last_fetch >= self.__fetch_interval:
+                self.patches_source.fetch()
+                pull_current_branch(patches_repo)

--- a/varats-core/varats/provider/patch/patch_provider.py
+++ b/varats-core/varats/provider/patch/patch_provider.py
@@ -6,6 +6,7 @@ applied during an experiment to alter the state of the project.
 """
 
 import os
+import time
 import typing as tp
 import warnings
 from pathlib import Path
@@ -378,6 +379,6 @@ class PatchProvider(Provider):
 
         with lock_file(lock_path):
             patches_repo = self._get_patches_repository()
-            if patches_repo.last_fetch >= self.fetch_interval:
+            if (time.time() - patches_repo.last_fetch) >= self.fetch_interval:
                 self.patches_source.fetch()
                 pull_current_branch(patches_repo)

--- a/varats-core/varats/provider/patch/patch_provider.py
+++ b/varats-core/varats/provider/patch/patch_provider.py
@@ -284,9 +284,9 @@ class PatchProvider(Provider):
 
     def __init__(self, project: tp.Type[Project], fetch_interval: int = 3600):
         super().__init__(project)
-        self.__fetch_interval = fetch_interval
+        self.fetch_interval = fetch_interval
 
-        self._update_local_patches_repo(fetch_interval)
+        self._update_local_patches_repo()
         repo = self._get_patches_repository()
 
         patches_project_dir = repo.worktree_path / self.project.NAME
@@ -302,7 +302,7 @@ class PatchProvider(Provider):
         # Update repository to have all upstream changes
         project_repo = get_local_project_repo(self.project.NAME)
 
-        if project_repo.last_fetch >= self.__fetch_interval:
+        if project_repo.last_fetch >= self.fetch_interval:
             fetch_repository(project_repo)
 
         for root, _, files in os.walk(patches_project_dir):
@@ -339,8 +339,7 @@ class PatchProvider(Provider):
 
     @classmethod
     def create_provider_for_project(
-        cls: tp.Type[ProviderType], project: tp.Type[Project],
-        fetch_interval: int
+        cls: tp.Type[ProviderType], project: tp.Type[Project]
     ) -> 'PatchProvider':
         """
         Creates a provider instance for the given project.
@@ -352,7 +351,7 @@ class PatchProvider(Provider):
         Returns:
             a provider instance for the given project
         """
-        return PatchProvider(project, fetch_interval)
+        return PatchProvider(project)
 
     @classmethod
     def create_default_provider(
@@ -379,6 +378,6 @@ class PatchProvider(Provider):
 
         with lock_file(lock_path):
             patches_repo = self._get_patches_repository()
-            if patches_repo.last_fetch >= self.__fetch_interval:
+            if patches_repo.last_fetch >= self.fetch_interval:
                 self.patches_source.fetch()
                 pull_current_branch(patches_repo)

--- a/varats-core/varats/utils/git_util.py
+++ b/varats-core/varats/utils/git_util.py
@@ -2,7 +2,6 @@
 import abc
 import logging
 import re
-import time
 import typing as tp
 from enum import Enum
 from pathlib import Path
@@ -183,18 +182,17 @@ class RepositoryHandle:
     @property
     def last_fetch(self) -> float:
         """
-        Returns the time in seconds since the last fetch operation.
+        Returns the time of the last fetch in seconds since epoch.
 
         Returns:
-            timestamp of the last fetch operation in milliseconds since the time of the call
+            timestamp of the last fetch operation in seconds since epoch, or
             0 if no fetch has been performed yet
         """
         fetch_head = self.repo_path / ".git" / "FETCH_HEAD"
         if not fetch_head.exists():
             return 0.0
 
-        time_epoch = time.time()
-        return time_epoch - fetch_head.stat().st_mtime
+        return fetch_head.stat().st_mtime
 
     def maybe_pygit_commit(
         self, commit_hash: tp.Union[CommitHash, str]

--- a/varats-core/varats/utils/git_util.py
+++ b/varats-core/varats/utils/git_util.py
@@ -2,6 +2,7 @@
 import abc
 import logging
 import re
+import time
 import typing as tp
 from enum import Enum
 from pathlib import Path
@@ -178,6 +179,22 @@ class RepositoryHandle:
             self.__libgit_repo = pygit2.Repository(str(self.repo_path))
 
         return self.__libgit_repo
+
+    @property
+    def last_fetch(self) -> float:
+        """
+        Returns the time in seconds since the last fetch operation.
+
+        Returns:
+            timestamp of the last fetch operation in milliseconds since the time of the call
+            0 if no fetch has been performed yet
+        """
+        fetch_head = self.repo_path / ".git" / "FETCH_HEAD"
+        if not fetch_head.exists():
+            return 0.0
+
+        time_epoch = time.time()
+        return time_epoch - fetch_head.stat().st_mtime
 
     def maybe_pygit_commit(
         self, commit_hash: tp.Union[CommitHash, str]


### PR DESCRIPTION
This adds a fetch interval to the patch provider to reduce the number of fetches made to GitHub repositories.

Previously each instantiation of a patch provider enforced a fetch on the projects repo to correctly identify the valid revisions of a patch. 
This leads to issues with experiment steps that use the `workload_commands` function from `workload_util`, as each call to  `can_be_executed` (from `VProjectCommand`) creates a new PatchProvider. 

This can lead to severe rate limiting by GitHub and ultimately failing experiments.