### PR TITLE
Replacing some linting and formatting tools with Ruff

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -28,8 +28,8 @@ jobs:
         pip install .
         pip install -r requirements.txt
         pip install mypy
-        pip install pylint
-        pylint --version
+        pip install ruff==0.15.2
+
     - name: Setup reviewdog
       run: |
         mkdir -p $HOME/bin && curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh| sh -s -- -b $HOME/bin
@@ -40,4 +40,4 @@ jobs:
         REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         reviewdog -runners=mypy -reporter=github-pr-check -conf=.reviewdog.yml
-        reviewdog -runners=pylint -reporter=github-pr-check -conf=.reviewdog.yml
+        reviewdog -runners=ruff -reporter=github-pr-check -conf=.reviewdog.yml

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -40,4 +40,4 @@ jobs:
         REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         reviewdog -runners=mypy -reporter=github-pr-check -conf=.reviewdog.yml
-        reviewdog -runners=ruff -reporter=github-pr-check -conf=.reviewdog.yml -filter-mode=file
+        reviewdog -runners=ruff -reporter=github-pr-check -conf=.reviewdog.yml -filter-mode=diff_context

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -40,4 +40,4 @@ jobs:
         REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         reviewdog -runners=mypy -reporter=github-pr-check -conf=.reviewdog.yml
-        reviewdog -runners=ruff -reporter=github-pr-check -conf=.reviewdog.yml
+        reviewdog -runners=ruff -reporter=github-pr-check -conf=.reviewdog.yml -filter-mode=file

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,7 +1,0 @@
-[settings]
-known_first_party = varats
-known_third_party = benchbuild
-multi_line_output=3
-use_parentheses = True
-include_trailing_comma: True
-line_length=80

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,9 +26,5 @@ repos:
     rev: 0.3.4
     hooks:
       - id: auto-walrus
-  - repo: https://github.com/google/yapf
-    rev: 'v0.43.0'
-    hooks:
-      - id: yapf
 
 exclude: ^tests/TEST_INPUTS/.*$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,11 +17,6 @@ repos:
     hooks:
       - id: ruff
         args: ["--fix"]
-  - repo: https://github.com/myint/docformatter.git
-    rev: eb1df347edd128b30cd3368dddc3aa65edcfac38
-    hooks:
-      - id: docformatter
-        args: ['--in-place', '--wrap-summaries=80', '--wrap-descriptions=80', '--pre-summary-newline']
   - repo: https://github.com/MarcoGorelli/auto-walrus
     rev: 0.3.4
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,11 +12,11 @@ repos:
       - id: name-tests-test
         args: ['--django']
         exclude: 'tests/helper_utils.py'
-  - repo: https://github.com/timothycrosley/isort.git
-    rev: 6.0.0
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.2
     hooks:
-      - id: isort
-        args: ['--nis']
+      - id: ruff
+        args: ["--fix"]
   - repo: https://github.com/myint/docformatter.git
     rev: eb1df347edd128b30cd3368dddc3aa65edcfac38
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,8 +15,9 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.2
     hooks:
-      - id: ruff
+      - id: ruff-check
         args: ["--fix"]
+      - id: ruff-format
   - repo: https://github.com/MarcoGorelli/auto-walrus
     rev: 0.3.4
     hooks:

--- a/.reviewdog.yml
+++ b/.reviewdog.yml
@@ -5,9 +5,8 @@ runner:
     errorformat:
       - "%f:%l:%c: %m"
     level: error
-
-  pylint:
-    name: pylint
-    cmd: pylint varats* -j 0
-    errorformat:
-      - "%f:%l:%c: %t%n: %m"
+  
+  ruff:
+    name: ruff
+    cmd: ruff check --output-format=rdjson
+    format: rdjson

--- a/.reviewdog.yml
+++ b/.reviewdog.yml
@@ -5,7 +5,7 @@ runner:
     errorformat:
       - "%f:%l:%c: %m"
     level: error
-  
+
   ruff:
     name: ruff
     cmd: ruff check --output-format=rdjson

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -76,40 +76,40 @@ add_module_names = True
 # Import pandas without the type checking flag to avoid import errors.
 # The exact reason for these errors is unknown but might be related to
 # incompatible cython versions (https://github.com/cython/cython/issues/1953)
-import pandas  # isort:skip
-import numpy.typing as npt  # isort:skip
+import pandas  # ruff: isort:skip
+import numpy.typing as npt  # ruff: isort:skip
 
 # The _typeshed module is not available during docs build, hence, we import
 # modules that require this module before setting the type checking flag.
-import scipy.stats  # isort:skip
+import scipy.stats  # ruff: isort:skip
 
 # Matplotlib >=3.8 has a type-checking-flag-guarded import of a symbol that does
 # not exist in the shipped version.
-import matplotlib.pyplot  # isort:skip
+import matplotlib.pyplot  # ruff: isort:skip
 
 # The autodocs typehints plugin does not resolve circular imports caused by type
 # annotations, so we have to manually break the circles.
-import rich.console  # isort:skip
-import cryptography.hazmat.backends  # isort:skip
-import cryptography.hazmat.backends.openssl.backend  # isort:skip
-import cryptography.exceptions  # isort:skip
-import click  # isort:skip
-import git  # isort:skip
-import github  # isort:skip
-import pygit2  # isort:skip
-import urllib3.exceptions  # isort:skip
+import rich.console  # ruff: isort:skip
+import cryptography.hazmat.backends  # ruff: isort:skip
+import cryptography.hazmat.backends.openssl.backend  # ruff: isort:skip
+import cryptography.exceptions  # ruff: isort:skip
+import click  # ruff: isort:skip
+import git  # ruff: isort:skip
+import github  # ruff: isort:skip
+import pygit2  # ruff: isort:skip
+import urllib3.exceptions  # ruff: isort:skip
 
 # Some packages use new syntax for type checking that isn't available to us
 import jwt.algorithms
 
-import typing as tp  # isort:skip
+import typing as tp  # ruff: isort:skip
 
 tp.TYPE_CHECKING = True
-import varats.mapping.commit_map  # isort:skip
-import varats.containers.containers  # isort:skip
-import varats.experiment.experiment_util  # isort:skip
-import varats.plot.plot  # isort:skip
-import varats.table.table  # isort:skip
+import varats.mapping.commit_map  # ruff: isort:skip
+import varats.containers.containers  # ruff: isort:skip
+import varats.experiment.experiment_util  # ruff: isort:skip
+import varats.plot.plot  # ruff: isort:skip
+import varats.table.table  # ruff: isort:skip
 
 tp.TYPE_CHECKING = False
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -9,6 +9,7 @@
 # -- Project information -----------------------------------------------------
 import importlib.metadata as metadata
 import logging
+
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,17 @@ markers = [
     "slow: this test is slow."
 ]
 
+[tool.ruff]
+line-length = 80
+
+[tool.ruff.lint]
+select = ["I"]  # I = import-sorting rules only
+
+[tool.ruff.lint.isort]
+known-first-party = ["varats"]
+known-third-party = ["benchbuild"]
+
+
 [tool.mypy]
 warn_return_any = true
 warn_unused_configs = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,6 +128,9 @@ select = [
   "E",      # pycodestyle errors
   "W",      # pycodestyle warnings
 
+  # pydocstyle
+  "D",
+
   # Ruff-specific rules
   "RUF",
 
@@ -189,12 +192,18 @@ ignore = [
   "ISC002", # multi-line-implicit-string-concatenation
 ]
 
+
+[tool.ruff.lint.pydocstyle]
+# Use Google-style docstrings.
+convention = "google"
+ignore-var-parameters = true
+
+
 [tool.ruff.lint.isort]
 known-first-party = ["varats"]
 known-third-party = ["benchbuild"]
 
 
-# Pylint settings to match .pylintrc configuration
 [tool.ruff.lint.pylint]
 max-args = 10
 max-bool-expr=6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -186,6 +186,7 @@ ignore = [
   "E114",   # indentation-with-invalid-multiple-comment
   "E117",   # over-indented
   "D206",   # docstring-tab-indentation
+  "D212",  # multi-line-summary-first-line
   "D300",   # triple-single-quotes
   "COM812", # missing-trailing-comma
   "COM819", # prohibited-trailing-comma

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,13 +127,13 @@ select = [
   "F",      # Pyflakes (undefined names, unused imports, etc.)
   "E",      # pycodestyle errors
   "W",      # pycodestyle warnings
-  
+
   # Ruff-specific rules
-  "RUF", 
+  "RUF",
 
   # refurb
-  "FURB",  
-  
+  "FURB",
+
   # Import sorting (replaces isort)
   "I",
 
@@ -141,10 +141,10 @@ select = [
   "N",
 
   # pandas-vet
-  "PD",    
+  "PD",
 
   # NumPy-specific rules
-  "NPY", 
+  "NPY",
 
   # flake8 rules
   "COM",    # flake8-commas
@@ -153,7 +153,7 @@ select = [
   "RET",    # flake8-return
   "ARG",    # flake8-unused-arguments
   "PTH",    # flake8-use-pathlib
-  "SIM",    # flake8-simplify  
+  "SIM",    # flake8-simplify
 
   # Full Pylint coverage available in Ruff
   "PLE",    # pylint errors

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,6 +119,7 @@ markers = [
 [tool.ruff]
 line-length = 80
 exclude = ["CVS", "gui", "filtertree_data.py", ".eggs", "docs/source/conf.py",]
+indent-width = 4
 
 [tool.ruff.lint]
 select = [
@@ -146,6 +147,8 @@ select = [
 # Ignoring specific rules that conflict with pre-ruff setup or are not needed
 ignore = [
   "PLW1514", # unspecified-encoding
+  "G004", # logging-f-string
+  "ISC002", # multi-line-implicit-string-concatenation
   "N815",  # mixed-case-variable-in-class-scope
   "PLW0177", # comparison-to-nan
   "PLW2901", # redefined-loop-variable
@@ -156,7 +159,7 @@ ignore = [
 
 [tool.ruff.lint.isort]
 known-first-party = ["varats"]
-known-third-party = ["benchbuild"]
+known-third-party = ["benchbuild", "enchant"]
 
 # McCabe complexity settings (replaces some of Pylint's DESIGN)
 [tool.ruff.lint.mccabe]
@@ -172,6 +175,7 @@ max-positional-args=10
 max-public-methods=20
 max-returns=6
 max-statements=50
+max-nested-blocks=5
 
 
 [tool.mypy]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,7 +146,6 @@ select = [
 
 # Ignoring specific rules that conflict with pre-ruff setup or are not needed
 ignore = [
-  "PLW1514", # unspecified-encoding
   "G004", # logging-f-string
   "ISC002", # multi-line-implicit-string-concatenation
   "N815",  # mixed-case-variable-in-class-scope

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,6 +134,14 @@ select = [
   # Naming conventions (replaces BASIC naming rules)
   "N",
 
+  # flake8 rules
+  "COM",    # flake8-commas
+  "A",      # flake8-builtins
+  "C4",     # flake8-comprehensions
+  "RET",    # flake8-return
+  "ARG",    # flake8-unused-arguments
+  "PTH",    # flake8-use-pathlib
+
   # Full Pylint coverage available in Ruff
   "PLE",    # pylint errors
   "PLW",    # pylint warnings

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,7 +171,7 @@ ignore = [
 
 [tool.ruff.lint.isort]
 known-first-party = ["varats"]
-known-third-party = ["benchbuild", "enchant"]
+known-third-party = ["benchbuild"]
 
 
 # Pylint settings to match .pylintrc configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,6 +157,7 @@ select = [
   "ARG",    # flake8-unused-arguments
   "PTH",    # flake8-use-pathlib
   "SIM",    # flake8-simplify
+  "FIX",    # flake8-fixme
 
   # Full Pylint coverage available in Ruff
   "PLE",    # pylint errors
@@ -167,9 +168,10 @@ select = [
 
 # Ignoring specific rules that conflict with pre-ruff setup or are not needed
 ignore = [
-  "G004", # logging-f-string
-  "PLR2004", # magic-value-comparison
-  "PLR5501", # collapsible-else-if
+  "G004",     # logging-f-string
+  "PLR2004",  # magic-value-comparison
+  "PLR5501",  # collapsible-else-if
+  "FIX004",   # line-contains-hack
 
   # Rules incompatible with ruff formatter
   "Q",      # all flake-8 quote rules

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,7 +150,6 @@ ignore = [
   "ISC002", # multi-line-implicit-string-concatenation
   "N815",  # mixed-case-variable-in-class-scope
   "PLW0177", # comparison-to-nan
-  "PLW2901", # redefined-loop-variable
   "PLR2004", # magic-value-comparison
   "PLR5501", # collapsible-else-if
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,12 +127,24 @@ select = [
   "F",      # Pyflakes (undefined names, unused imports, etc.)
   "E",      # pycodestyle errors
   "W",      # pycodestyle warnings
+  
+  # Ruff-specific rules
+  "RUF", 
 
+  # refurb
+  "FURB",  
+  
   # Import sorting (replaces isort)
   "I",
 
   # Naming conventions (replaces BASIC naming rules)
   "N",
+
+  # pandas-vet
+  "PD",    
+
+  # NumPy-specific rules
+  "NPY", 
 
   # flake8 rules
   "COM",    # flake8-commas
@@ -141,6 +153,7 @@ select = [
   "RET",    # flake8-return
   "ARG",    # flake8-unused-arguments
   "PTH",    # flake8-use-pathlib
+  "SIM",    # flake8-simplify  
 
   # Full Pylint coverage available in Ruff
   "PLE",    # pylint errors

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,7 +147,6 @@ select = [
 # Ignoring specific rules that conflict with pre-ruff setup or are not needed
 ignore = [
   "G004", # logging-f-string
-  "ISC002", # multi-line-implicit-string-concatenation
   "PLR2004", # magic-value-comparison
   "PLR5501", # collapsible-else-if
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,6 +167,18 @@ ignore = [
   "G004", # logging-f-string
   "PLR2004", # magic-value-comparison
   "PLR5501", # collapsible-else-if
+
+  # Rules incompatible with ruff formatter
+  "Q",      # all flake-8 quote rules
+  "W191",   # tab-indentation
+  "E111",   # indentation-with-invalid-multiple
+  "E114",   # indentation-with-invalid-multiple-comment
+  "E117",   # over-indented
+  "D206",   # docstring-tab-indentation
+  "D300",   # triple-single-quotes
+  "COM812", # missing-trailing-comma
+  "COM819", # prohibited-trailing-comma
+  "ISC002", # multi-line-implicit-string-concatenation
 ]
 
 [tool.ruff.lint.isort]
@@ -185,6 +197,12 @@ max-public-methods=20
 max-returns=6
 max-statements=50
 max-nested-blocks=5
+
+
+# Ruff Formatter settings
+[tool.ruff.format]
+indent-style = "space"
+quote-style = "preserve"
 
 
 [tool.mypy]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,7 +149,6 @@ ignore = [
   "G004", # logging-f-string
   "ISC002", # multi-line-implicit-string-concatenation
   "N815",  # mixed-case-variable-in-class-scope
-  "PLW0177", # comparison-to-nan
   "PLR2004", # magic-value-comparison
   "PLR5501", # collapsible-else-if
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,7 +158,7 @@ select = [
   "PTH",    # flake8-use-pathlib
   "SIM",    # flake8-simplify
   "FIX",    # flake8-fixme
-  "BLE"  # flake8-blind-except
+  "BLE",  # flake8-blind-except
   "TID251", # banned-api (flake8-tidy-imports)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,9 +134,6 @@ select = [
   # Naming conventions (replaces BASIC naming rules)
   "N",
 
-  # McCabe complexity (replaces DESIGN complexity only)
-  "C901",
-
   # Full Pylint coverage available in Ruff
   "PLE",    # pylint errors
   "PLW",    # pylint warnings
@@ -155,9 +152,6 @@ ignore = [
 known-first-party = ["varats"]
 known-third-party = ["benchbuild", "enchant"]
 
-# McCabe complexity settings (replaces some of Pylint's DESIGN)
-[tool.ruff.lint.mccabe]
-max-complexity = 12
 
 # Pylint settings to match .pylintrc configuration
 [tool.ruff.lint.pylint]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,7 +153,6 @@ ignore = [
   "PLW2901", # redefined-loop-variable
   "PLR2004", # magic-value-comparison
   "PLR5501", # collapsible-else-if
-  "PLW1641", # eq-without-hash
 ]
 
 [tool.ruff.lint.isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,6 +146,9 @@ select = [
   # NumPy-specific rules
   "NPY",
 
+  # pyupgrade rules
+  "UP034",   # extraneous-parentheses
+
   # flake8 rules
   "COM",    # flake8-commas
   "A",      # flake8-builtins

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,6 +158,9 @@ select = [
   "PTH",    # flake8-use-pathlib
   "SIM",    # flake8-simplify
   "FIX",    # flake8-fixme
+  "BLE"  # flake8-blind-except
+  "TID251", # banned-api (flake8-tidy-imports)
+
 
   # Full Pylint coverage available in Ruff
   "PLE",    # pylint errors
@@ -202,6 +205,11 @@ max-public-methods=20
 max-returns=6
 max-statements=50
 max-nested-blocks=5
+
+
+[tool.ruff.lint.flake8-tidy-imports.banned-api]
+"optparse".msg = "optparse is deprecated."
+"tkinter.tix".msg = "tkinter.tix is deprecated."
 
 
 # Ruff Formatter settings

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,13 +118,60 @@ markers = [
 
 [tool.ruff]
 line-length = 80
+exclude = ["CVS", "gui", "filtertree_data.py", ".eggs", "docs/source/conf.py",]
 
 [tool.ruff.lint]
-select = ["I"]  # I = import-sorting rules only
+select = [
+  # Core Python correctness
+  "F",      # Pyflakes (undefined names, unused imports, etc.)
+  "E",      # pycodestyle errors
+  "W",      # pycodestyle warnings
+
+  # Import sorting (replaces isort)
+  "I",
+
+  # Naming conventions (replaces BASIC naming rules)
+  "N",
+
+  # McCabe complexity (replaces DESIGN complexity only)
+  "C901",
+
+  # Full Pylint coverage available in Ruff
+  "PLE",    # pylint errors
+  "PLW",    # pylint warnings
+  "PLR",    # pylint refactor
+  "PLC",    # pylint convention rules
+]
+
+# Ignoring specific rules that conflict with pre-ruff setup or are not needed
+ignore = [
+  "PLW1514", # unspecified-encoding
+  "N815",  # mixed-case-variable-in-class-scope
+  "PLW0177", # comparison-to-nan 
+  "PLW2901", # redefined-loop-variable
+  "PLR2004", # magic-value-comparison
+  "PLR5501", # collapsible-else-if
+  "PLW1641", # eq-without-hash
+]
 
 [tool.ruff.lint.isort]
 known-first-party = ["varats"]
 known-third-party = ["benchbuild"]
+
+# McCabe complexity settings (replaces some of Pylint's DESIGN)
+[tool.ruff.lint.mccabe]
+max-complexity = 12
+
+# Pylint settings to match .pylintrc configuration
+[tool.ruff.lint.pylint]
+max-args = 10 
+max-bool-expr=6
+max-branches=12
+max-locals=20
+max-positional-args=10
+max-public-methods=20
+max-returns=6
+max-statements=50
 
 
 [tool.mypy]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,7 +148,6 @@ select = [
 ignore = [
   "G004", # logging-f-string
   "ISC002", # multi-line-implicit-string-concatenation
-  "N815",  # mixed-case-variable-in-class-scope
   "PLR2004", # magic-value-comparison
   "PLR5501", # collapsible-else-if
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,7 +147,7 @@ select = [
 ignore = [
   "PLW1514", # unspecified-encoding
   "N815",  # mixed-case-variable-in-class-scope
-  "PLW0177", # comparison-to-nan 
+  "PLW0177", # comparison-to-nan
   "PLW2901", # redefined-loop-variable
   "PLR2004", # magic-value-comparison
   "PLR5501", # collapsible-else-if
@@ -164,7 +164,7 @@ max-complexity = 12
 
 # Pylint settings to match .pylintrc configuration
 [tool.ruff.lint.pylint]
-max-args = 10 
+max-args = 10
 max-bool-expr=6
 max-branches=12
 max-locals=20

--- a/varats/varats/table/tables.py
+++ b/varats/varats/table/tables.py
@@ -31,7 +31,6 @@ if tp.TYPE_CHECKING:
 
 LOG = logging.getLogger(__name__)
 
-# introducing test line to trigger CI and test if precommit blocks PR after warning due to pylint violations
 
 class TableFormat(Enum):
     """List of supported TableFormats."""

--- a/varats/varats/table/tables.py
+++ b/varats/varats/table/tables.py
@@ -31,6 +31,7 @@ if tp.TYPE_CHECKING:
 
 LOG = logging.getLogger(__name__)
 
+# introducing test line to trigger CI and test if precommit blocks PR after warning due to pylint violations
 
 class TableFormat(Enum):
     """List of supported TableFormats."""


### PR DESCRIPTION
Following tools are replaced in this PR:
1. Isort
2. Docformatter
3. Yapf
4. Pylint